### PR TITLE
perf(model): replace pjit with pmap

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,4 @@
 data:
-    path: gs://ggpt4/the-char-pile/*
     datasets_used_per_step: 128
     interleaved_datasets: 256
     parallel_workers: 128
@@ -8,20 +7,19 @@ dims:
     sizes:
         sequence: 65536
         batch: 8
-        depth: 16
+        depth: 4
         features_per_head: 256
-        intermediate_replicated: 512
-        intermediate_parallel: 512
 optimizer:
-    exponential_decay: 2.0e-05
-    gradient_clip: 0.1
-    learning_rate: 0.01
+    exponential_decay: 1.0e-05
+    gradient_clip: 0.01
+    learning_rate: 0.001
     warmup_end: 4096
 training:
-    loss_top_p: 1
     device_steps: 32
     device_unroll: 1
     trace:
         do_trace: false
         start_step: 2
         stop_step: 8
+model:
+    feed_forward_factor: 2

--- a/main.py
+++ b/main.py
@@ -37,12 +37,16 @@ def jitless_step(while_ctx_dict: typing.Dict[str, typing.Any]) -> typing.Dict[st
 
 def get_parameters(ctx: Context, inp: jnp.ndarray):
     def _fn(x: jnp.ndarray, idx: jnp.ndarray):
+        initial_seed = ctx.seed
+        initial_prng_key = ctx.prng_key
         ctx.seed += idx
         ctx.prng_key = jax.random.PRNGKey(ctx.seed)
         body_ctx(ctx, x)
         params = ctx.parameters
         var = ctx.parameter_variance
         ctx.parameters = {}
+        ctx.prng_key = initial_prng_key
+        ctx.seed = initial_seed
         ctx.parameter_variance = {}
         return params, var
 

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def jitless_step(while_ctx_dict: typing.Dict[str, typing.Any]) -> typing.Dict[st
 def get_parameters(ctx: Context, inp: jnp.ndarray):
     def _fn(x: jnp.ndarray, idx: jnp.ndarray):
         ctx.seed += idx
-        ctx.prng_key = random.PRNGKey(ctx.seed)
+        ctx.prng_key = jax.random.PRNGKey(ctx.seed)
         body_ctx(ctx, x)
         params = ctx.parameters
         var = ctx.parameter_variance

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from src.data import text_dataset
 from src.model import compute, body_ctx
 from src.optimizer import get_current_lr, update
 from src.utils.wandb import WandbLog
+from src.utils.checkpoint import write_ckpt
 
 
 def train_step(while_ctx_dict: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
@@ -142,7 +143,8 @@ def main():
                 jax.profiler.start_trace(ctx.training.trace.output_path)
             if idx == ctx.training.trace.stop_step:
                 jax.profiler.stop_trace()
-
+        if idx % ctx.training.checkpoint_interval == 0:
+            write_ckpt(ctx)
 
 if __name__ == '__main__':
     main()

--- a/main.py
+++ b/main.py
@@ -20,11 +20,11 @@ from src.utils.wandb import WandbLog
 def train_step(while_ctx_dict: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
     wctx = WhileTrainContext(while_ctx_dict)
     grad_fn = jax.value_and_grad(compute, 0, True)
-    (top_loss, loss), grads = grad_fn(wctx.ctx.parameters,
+    (loss, accuracy), grads = grad_fn(wctx.ctx.parameters,
                                       wctx.data[wctx.current_step % wctx.ctx.training.device_steps])
     update(wctx.ctx, grads, wctx.current_step)
     wctx.loss += loss
-    wctx.top_loss += top_loss
+    wctx.top_loss += accuracy
     wctx.current_step += 1
     return wctx.serialize()
 

--- a/main.py
+++ b/main.py
@@ -105,7 +105,7 @@ def main():
     buffer_count = sum(util.prod(param.shape) for name, param in ctx.parameters.items()) - parameter_count
 
     partition = {'parameters': {k: 0 for k in ctx.parameters.keys()},
-                 'parameter_variance': {k: None for k in ctx.parameters.keys()},
+                 'parameter_variance': {k: None for k in ctx.parameter_variance.keys()},
                  'data': None, 'current_step': None, 'loss': None, 'top_loss': None}
     step = train_loop(wctx, timeit(f"PMapping across {ParallelAxes.model}", jax.pmap, jitless_step, ParallelAxes.model,
                                    in_axes=(partition,), out_axes=partition))

--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ def get_optimizer_state(ctx: Context):
         update(new_ctx, grads, jnp.ones((), dtype=new_ctx.model.computation_dtype))
         return new_ctx.parameters
 
-    pmapped = jax.pmap(_fn, ParallelAxes.model, in_axes=(0, 0), out_axes=0)
+    pmapped = jax.pmap(_fn, ParallelAxes.model, in_axes=({k: 0 for k in ctx.parameters.keys()},) * 2, out_axes=0)
     ctx.parameters = pmapped(ctx.parameters, {name: jnp.zeros_like(param) for name, param in ctx.parameters.items()})
     jnp.ones([], dtype=ctx.model.computation_dtype)
 

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ def get_optimizer_state(ctx: Context):
         update(new_ctx, grads, jnp.ones((), dtype=new_ctx.model.computation_dtype))
         return new_ctx.parameters
 
-    pmapped = jax.pmap(_fn, ParallelAxes.model, in_axes=({k: 0 for k in ctx.parameters.keys()}), out_axes=0)
+    pmapped = jax.pmap(_fn, ParallelAxes.model, in_axes=({k: 0 for k in ctx.parameters.keys()},), out_axes=0)
     ctx.parameters = pmapped(ctx.parameters)
 
 

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ def get_parameters(ctx: Context, inp: jnp.ndarray):
 
 
 def get_optimizer_state(ctx: Context):
-    def _fn(parameters: typing.Dict[str], grads: typing.Dict[str]):
+    def _fn(parameters: typing.Dict[str, jnp.ndarray], grads: typing.Dict[str, jnp.ndarray]):
         ctx.parameters = parameters
         update(ctx, grads, jnp.ones((), dtype=ctx.model.computation_dtype))
         params = ctx.parameters

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ def get_parameters(ctx: Context, inp: jnp.ndarray):
 
     inp = jnp.broadcast_to(inp, (ctx.dims.sizes.heads,) + inp.shape)
     ctx.parameters = jax.pmap(_fn, ParallelAxes.model, in_axes=0, out_axes=0)(inp)
-    ctx.parameter_dims = {name: [ctx.dims.heads] + dims for name, dims in ctx.parameter_dims}
+    ctx.parameter_dims = {name: [ctx.dims.heads] + dims for name, dims in ctx.parameter_dims.items()}
 
 
 def sharding(ctx: Context, dims: typing.List[str], axis: ParallelAxes):

--- a/setup.sh
+++ b/setup.sh
@@ -3,4 +3,4 @@ python3 -m pip install --upgrade tensorflow==2.4.2 jsonpickle
 python3 -m pip install --upgrade "jax[tpu]>=0.2.18" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 python3 -m pip uninstall tensorboard tbp-nightly tb-nightly tensorboard-plugin-profile -y
 python3 -m pip install tensorboard==2.4.0
-python3 -m pip install tensorboard-plugin-profile
+python3 -m pip install tensorboard-plugin-profile wandb

--- a/src/backend.py
+++ b/src/backend.py
@@ -107,6 +107,7 @@ def get_param(ctx: Context, name: str, str_shape: typing.Optional[typing.List[st
     prefix_name = prefixed_name(ctx, name)
     depth_indexing &= not ctx.model.weight_sharing
     if depth_indexing:
+        assert idx is not None, "idx has to be set when depth indexing is true"
         str_shape = [ctx.dims.depth] + str_shape
     shape = dims_to_shape(ctx, str_shape)
     if prefix_name not in ctx.parameters:

--- a/src/backend.py
+++ b/src/backend.py
@@ -115,14 +115,14 @@ def get_param(ctx: Context, name: str, str_shape: typing.Optional[typing.List[st
         if std is None and mean is None:
             param, var = stacked_orthogonal_init(ctx, str_shape, column_axes, split_dims)
             param *= scale * post_variance_scale
-            ctx.parameter_variance[name] = var * scale ** 2 * learning_rate_scale
+            ctx.parameter_variance[prefix_name] = var * scale ** 2 * learning_rate_scale
         else:
             param = random.normal(ctx.prng_key, shape, ctx.model.storage_dtype)
             if std is not None:
                 param *= std
             if mean is not None:
                 param += mean
-            ctx.parameter_variance[name] = learning_rate_scale
+            ctx.parameter_variance[prefix_name] = learning_rate_scale
         param = param.astype(ctx.model.storage_dtype)
         assign(ctx, name, param)
     param = ctx.parameters[prefix_name]

--- a/src/backend.py
+++ b/src/backend.py
@@ -101,7 +101,7 @@ def get_param(ctx: Context, name: str, str_shape: typing.Optional[typing.List[st
               std: typing.Optional[float] = None, mean: typing.Optional[float] = None, column_axes: int = 1,
               scale: float = 1., post_variance_scale: float = 1,
               split_dims: typing.Optional[typing.List[str]] = None,
-              depth_indexing: bool = False) -> jnp.ndarray:
+              depth_indexing: bool = False, idx: typing.Optional[jnp.ndarray] = None) -> jnp.ndarray:
     if split_dims is None:
         split_dims = [ctx.dims.depth]
     prefix_name = prefixed_name(ctx, name)
@@ -125,7 +125,7 @@ def get_param(ctx: Context, name: str, str_shape: typing.Optional[typing.List[st
         assign(ctx, name, param)
     param = ctx.parameters[prefix_name]
     if depth_indexing:
-        param = param[ctx.depth_index].reshape(param.shape[1:])
+        param = param[idx].reshape(param.shape[1:])
     return param.astype(ctx.model.computation_dtype)
 
 

--- a/src/context.py
+++ b/src/context.py
@@ -160,6 +160,7 @@ class Model(DataClass):
 
 
 class Training(DataClass):
+    z_loss: float = 1e-4
     loss_top_p: float = 0.4
     loss_top_snap: int = 128  # snap top_p * batch to closest multiple
     device_steps: int = 1024

--- a/src/context.py
+++ b/src/context.py
@@ -129,13 +129,11 @@ class WandB(DataClass):
 
 
 class Optimizer(DataClass):
-    learning_rate: float = 1
-    gradient_clip: float = 0.1
-    momentum_beta: float = 0.9
+    learning_rate: float = 0.01
+    gradient_clip: float = 0.01
     adam_beta1: float = 0.9
     adam_beta2: float = 0.99
-    momentum_type: MomentumType = MomentumType.nesterov
-    weight_decay: float = 1e-3
+    weight_decay: float = 0.1
     warmup_end: int = 4096
     exponential_decay: float = 1e-4
 
@@ -159,7 +157,7 @@ class Model(DataClass):
 
 
 class Training(DataClass):
-    z_loss: float = 1e-4
+    z_loss: float = 0.01
     loss_top_p: float = 0.4
     loss_top_snap: int = 128  # snap top_p * batch to closest multiple
     device_steps: int = 1024

--- a/src/context.py
+++ b/src/context.py
@@ -148,7 +148,6 @@ class Model(DataClass):
     group_linear_factor: int = 2
     experts: int = 1  # TODO: Add dense MoE
     momentumnet_beta: float = 0.9
-    depth: int = 32
     depth_unroll: int = 8
     leaky_relu_slope: float = 0.02
     activation_std: float = 0.5893595616022745

--- a/src/context.py
+++ b/src/context.py
@@ -129,7 +129,7 @@ class WandB(DataClass):
 
 
 class Optimizer(DataClass):
-    learning_rate: float = 1e-3
+    learning_rate: float = 1
     gradient_clip: float = 0.1
     momentum_beta: float = 0.9
     adam_beta1: float = 0.9
@@ -155,7 +155,7 @@ class Model(DataClass):
     weight_sharing: bool = False
     feed_forward_factor: int = 2
     storage_dtype: str = "float32"  # valid jax.numpy.storage_dtype
-    computation_dtype: str = "bfloat16"
+    computation_dtype: str = "float32"
 
 
 class Training(DataClass):

--- a/src/context.py
+++ b/src/context.py
@@ -186,7 +186,6 @@ class Context(DataClass):
         self.seed = 0
         self.global_prefix = ''
 
-        self.depth_index: typing.Optional[jnp.ndarray] = None
         self.name_cache: typing.Dict[str, int] = {}
         self.parameters: typing.Dict[str, jnp.ndarray] = {}
         self.parameter_variance: typing.Dict[str, float] = {}

--- a/src/context.py
+++ b/src/context.py
@@ -73,14 +73,14 @@ class DataContext(DataClass):
 
 
 class DimSizes(DataClass):
-    batch: int = 256
+    batch: int = 8
     full_conv_kernel: int = 9
     depthwise_conv_kernel: int = 49
-    features_per_head: int = 512
+    features_per_head: int = 256
     heads: int = 8
-    sequence: int = 256
+    sequence: int = 65536
     one: int = 1
-    depth: int = 32
+    depth: int = 4
 
     def __init__(self, data: DataContext, group_linear_factor: float, feed_forward_factor: float):
         self.vocab: int = data.vocab_size
@@ -129,13 +129,13 @@ class WandB(DataClass):
 
 
 class Optimizer(DataClass):
-    learning_rate: float = 0.01
+    learning_rate: float = 0.001
     gradient_clip: float = 0.01
     adam_beta1: float = 0.9
     adam_beta2: float = 0.99
     weight_decay: float = 0.1
     warmup_end: int = 4096
-    exponential_decay: float = 1e-4
+    exponential_decay: float = 1e-5
 
 
 class Model(DataClass):
@@ -144,24 +144,19 @@ class Model(DataClass):
     scan_unroll: int = 1
     norm_eps: float = 1e-5
     group_linear_factor: int = 2
-    experts: int = 1  # TODO: Add dense MoE
-    momentumnet_beta: float = 0.9
-    depth_unroll: int = 8
     leaky_relu_slope: float = 0.02
     activation_std: float = 0.5893595616022745
     masked_attention: bool = True
     weight_sharing: bool = False
     feed_forward_factor: int = 2
     storage_dtype: str = "float32"  # valid jax.numpy.storage_dtype
-    computation_dtype: str = "float32"
+    computation_dtype: str = "bfloat16"
 
 
 class Training(DataClass):
     checkpoint_path: str = "gs://ggpt4/homebrewnlp-checkpoint/"
     checkpoint_interval: float = 16384
     z_loss: float = 0.01
-    loss_top_p: float = 0.4
-    loss_top_snap: int = 128  # snap top_p * batch to closest multiple
     device_steps: int = 1024
     device_unroll: int = 16
     steps: int = 2 ** 16

--- a/src/context.py
+++ b/src/context.py
@@ -60,7 +60,7 @@ def init_class_copy(instance: DataClass, config: typing.Dict[str, typing.Any]) -
 
 
 class DataContext(DataClass):
-    path: str = "gs://obst-euw4a-aa/the-small-chunk-char-pile/*"
+    path: str = "gs://ggpt4/the-char-pile/*"
     shuffle_buffer: int = 0
     parallel_workers: int = 128
     interleaved_datasets: int = 1024
@@ -157,6 +157,8 @@ class Model(DataClass):
 
 
 class Training(DataClass):
+    checkpoint_path: str = "gs://ggpt4/homebrewnlp-checkpoint/"
+    checkpoint_interval: float = 16384
     z_loss: float = 0.01
     loss_top_p: float = 0.4
     loss_top_snap: int = 128  # snap top_p * batch to closest multiple

--- a/src/context.py
+++ b/src/context.py
@@ -141,6 +141,7 @@ class Optimizer(DataClass):
 
 
 class Model(DataClass):
+    rezero_learning_rate_scale: float = 0.01
     device_halo_size: int = 3
     scan_unroll: int = 1
     norm_eps: float = 1e-5

--- a/src/model.py
+++ b/src/model.py
@@ -194,7 +194,7 @@ def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typi
     log_z = lax.log(lax.exp(src - max_logit).sum(-1, keepdims=True)) + max_logit
     loss = log_z - src * one_hot(tgt.astype(src.dtype), src.shape[-1])
     loss = loss.mean()
-    accuracy = (jnp.argmax(src, 1) == tgt).astype(jnp.float32).mean()
+    accuracy = (jnp.argmax(src, 2) == tgt).astype(jnp.float32).mean()
     if ctx.training.z_loss:
         loss += jnp.square(log_z) * (ctx.training.z_loss / tgt.size)
     return loss, accuracy

--- a/src/model.py
+++ b/src/model.py
@@ -191,7 +191,7 @@ def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typi
 
     max_logit = lax.stop_gradient(src).max(-1, keepdims=True)
     log_z = lax.log(lax.exp(src - max_logit).sum(-1, keepdims=True)) + max_logit
-    loss = log_z - src * one_hot(tgt.astype(src.dtype), src.shape[-1])
+    loss = src * one_hot(tgt.astype(src.dtype), src.shape[-1]) - log_z
     loss = loss.mean()
     accuracy = (jnp.argmax(src, 2) == tgt).astype(jnp.float32).mean()
     if ctx.training.z_loss:

--- a/src/model.py
+++ b/src/model.py
@@ -29,6 +29,8 @@ def psum(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
 def normalize(ctx: Context, inp: jnp.ndarray, idx: typing.Optional[jnp.ndarray]) -> jnp.ndarray:
     ctx = ctx.add_to_prefix("normalization")
     scale = get_param(ctx, "scale", [ctx.dims.heads, ctx.dims.one], std=0, depth_indexing=idx is not None, idx=idx)
+    if ctx.is_initializing:
+        return inp
     return inp / norm(ctx, inp, -1, True) * (1 + scale)
 
 

--- a/src/model.py
+++ b/src/model.py
@@ -191,8 +191,8 @@ def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typi
 
     max_logit = lax.stop_gradient(src).max(-1, keepdims=True)
     log_z = lax.log(lax.exp(src - max_logit).sum(-1, keepdims=True)) + max_logit
-    loss = src * one_hot(tgt.astype(src.dtype), src.shape[-1]) - log_z
-    loss = loss.mean()
+    loss = (src - log_z) * one_hot(tgt.astype(src.dtype), src.shape[-1])
+    loss = -loss.mean()
     accuracy = (jnp.argmax(src, 2) == tgt).astype(jnp.float32).mean()
     if ctx.training.z_loss:
         loss += jnp.square(log_z).mean() * ctx.training.z_loss

--- a/src/model.py
+++ b/src/model.py
@@ -142,8 +142,7 @@ def input_embed(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
 
 def output_embed_shard(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
     ctx = ctx.add_to_prefix("output_embed")
-    embd = get_param(ctx, "weight", [ctx.dims.features_per_head, ctx.dims.vocab], std=0,
-                     learning_rate_scale=1 / (ctx.dims.sizes.heads * ctx.dims.sizes.features_per_head))
+    embd = get_param(ctx, "weight", [ctx.dims.features_per_head, ctx.dims.vocab], std=0)
     if ctx.is_initializing:
         return inp
     return matmul(inp, embd)

--- a/src/model.py
+++ b/src/model.py
@@ -87,7 +87,6 @@ def feed_forward_features(ctx: Context, in_dim: str, out_dim: str, idx: jnp.ndar
 def group_feed_forward(ctx: Context, inp: jnp.ndarray, idx: jnp.ndarray) -> jnp.ndarray:
     ctx = ctx.add_to_prefix("group_feed_forward")
     inp_weight, out_weight = feed_forward_features(ctx, ctx.dims.features_per_head, ctx.dims.intermediate_parallel, idx)
-    inp = normalize(ctx, inp)
 
     if ctx.is_initializing:
         return inp
@@ -102,7 +101,6 @@ def feed_forward(ctx: Context, inp: jnp.ndarray, idx: jnp.ndarray) -> jnp.ndarra
     ctx = ctx.add_to_prefix("feed_forward")
     inp_weight, out_weight = feed_forward_features(ctx, ctx.dims.features_per_head, ctx.dims.intermediate_replicated,
                                                    idx)
-    inp = normalize(ctx, inp)
 
     if ctx.is_initializing:
         return inp

--- a/src/model.py
+++ b/src/model.py
@@ -216,10 +216,10 @@ def momentumnet_side(ctx: Context):
 def revnet_out(src: typing.Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]) -> jnp.ndarray:
     @jax.custom_gradient
     def _fn(x0: jnp.ndarray, x0_back: jnp.ndarray, x1: jnp.ndarray, x1_back: jnp.ndarray):
-        def _grad(dy) -> typing.Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
-            return dy, x0, dy, x1
+        def _grad(dy) -> typing.Tuple[jnp.ndarray, jnp.ndarray, None, jnp.ndarray]:
+            return dy, x0, None, x1
 
-        return x0 + x1, _grad
+        return x0, _grad
 
     return _fn(*src)
 

--- a/src/model.py
+++ b/src/model.py
@@ -199,7 +199,7 @@ def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typi
 
 def momentumnet_main(ctx: Context, fn: typing.Callable[[Context, jnp.ndarray, jnp.ndarray], jnp.ndarray]):
     def _fn(sub_ctx: Context, x: jnp.ndarray, idx: jnp.ndarray) -> jnp.ndarray:
-        inp = x * (1 - ctx.model.momentumnet_beta) / ctx.model.momentumnet_beta ** (idx + 1)
+        inp = x * ctx.model.momentumnet_beta ** idx
         out = fn(sub_ctx, inp, idx)
         return rezero(sub_ctx, out, idx)
 
@@ -208,7 +208,7 @@ def momentumnet_main(ctx: Context, fn: typing.Callable[[Context, jnp.ndarray, jn
 
 def momentumnet_side(ctx: Context):
     def _fn(_ignored: Context, x: jnp.ndarray, idx: jnp.ndarray) -> jnp.ndarray:
-        return x * ctx.model.momentumnet_beta ** idx
+        return x * (1 - ctx.model.momentumnet_beta) / ctx.model.momentumnet_beta ** (idx + 1)
 
     return _fn
 

--- a/src/model.py
+++ b/src/model.py
@@ -175,7 +175,7 @@ def reversible(ctx: Context, fn: typing.Callable[[Context, jnp.ndarray, jnp.ndar
 
 
 def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typing.Tuple[jnp.ndarray, jnp.ndarray]:
-    src = psum(ctx, src)
+    src = psum(ctx, src)  # TODO: Split batch across model parallel
     max_logit = lax.stop_gradient(src).max(-1, keepdims=True)
     log_z = lax.log(lax.exp(src - max_logit).sum(-1, keepdims=True)) + max_logit
     loss = log_z - jnp.take_along_axis(src, tgt.reshape(*tgt.shape, 1), -1)

--- a/src/model.py
+++ b/src/model.py
@@ -191,7 +191,7 @@ def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typi
 
     max_logit = lax.stop_gradient(src).max(-1, keepdims=True)
     log_z = lax.log(lax.exp(src - max_logit).sum(-1, keepdims=True)) + max_logit
-    loss = (src * one_hot(tgt.astype(src.dtype), src.shape[-1])).sum(-1, keepdim=True) - log_z
+    loss = (src * one_hot(tgt.astype(src.dtype), src.shape[-1])).sum(-1, keepdims=True) - log_z
     loss = -loss.mean()
     accuracy = (jnp.argmax(src, 2) == tgt).astype(jnp.float32).mean()
     if ctx.training.z_loss:

--- a/src/model.py
+++ b/src/model.py
@@ -31,7 +31,7 @@ def normalize(ctx: Context, inp: jnp.ndarray, idx: typing.Optional[jnp.ndarray])
     scale = get_param(ctx, "scale", [ctx.dims.heads, ctx.dims.one], std=0, depth_indexing=idx is not None, idx=idx)
     if ctx.is_initializing:
         return inp
-    return inp / norm(ctx, inp, -1, True) * (1 + scale)
+    return inp * (norm(ctx, inp, -1, True) * (1 + scale))
 
 
 def pool_heads(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:

--- a/src/model.py
+++ b/src/model.py
@@ -99,8 +99,7 @@ def conv_block(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
 def feed_forward_features(ctx: Context, in_dim: str, out_dim: str) -> typing.Tuple[
     jnp.ndarray, jnp.ndarray]:
     inp_weight = get_param(ctx, "inp_weight", [in_dim, out_dim], scale=1 / ctx.model.activation_std)
-    out_weight = get_param(ctx, "out_weight", [out_dim, in_dim], scale=ctx.dims.sizes.depth ** -0.5,
-                           column_axes=2)
+    out_weight = get_param(ctx, "out_weight", [out_dim, in_dim], scale=ctx.dims.sizes.depth ** -0.5)
     return inp_weight, out_weight
 
 

--- a/src/model.py
+++ b/src/model.py
@@ -30,7 +30,7 @@ def psum(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
 
 def normalize(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
     ctx = ctx.add_to_prefix("normalization")
-    scale = get_param(ctx, "scale", [ctx.dims.one], std=0)
+    weight = get_param(ctx, "scale", [ctx.dims.one], std=0)
 
     @jax.custom_gradient
     def _fn(src: jnp.ndarray):
@@ -47,7 +47,7 @@ def normalize(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
 
         return out, _grad
 
-    return _fn(inp) * (1 + scale)
+    return _fn(inp) * (1 + weight)
 
 
 def pool_heads(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:

--- a/src/model.py
+++ b/src/model.py
@@ -196,7 +196,7 @@ def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typi
     loss = loss.mean()
     accuracy = (jnp.argmax(src, 2) == tgt).astype(jnp.float32).mean()
     if ctx.training.z_loss:
-        loss += jnp.square(log_z) * (ctx.training.z_loss / tgt.size)
+        loss += jnp.square(log_z).mean() * (ctx.training.z_loss / tgt.size)
     return loss, accuracy
 
 

--- a/src/model.py
+++ b/src/model.py
@@ -189,9 +189,9 @@ def psum_scatter(inp: jnp.ndarray) -> jnp.ndarray:
 def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typing.Tuple[jnp.ndarray, jnp.ndarray]:
     src = lax.psum(src, ParallelAxes.model)
 
-    max_logit = lax.stop_gradient(src).max(-1, keepdims=True)
-    log_z = lax.log(lax.exp(src - max_logit).sum(-1, keepdims=True)) + max_logit
-    loss = (src - log_z) * one_hot(tgt.astype(src.dtype), src.shape[-1])
+    max_logit = lax.stop_gradient(src).max(-1)
+    log_z = lax.log(lax.exp(src - max_logit).sum(-1)) + max_logit
+    loss = (src * one_hot(tgt.astype(src.dtype), src.shape[-1])).sum(-1) - log_z
     loss = -loss.mean()
     accuracy = (jnp.argmax(src, 2) == tgt).astype(jnp.float32).mean()
     if ctx.training.z_loss:

--- a/src/model.py
+++ b/src/model.py
@@ -170,7 +170,7 @@ def reversible(ctx: Context, fn: typing.Callable[[Context, jnp.ndarray, jnp.ndar
                                                       jnp.ndarray, jnp.ndarray, None]:
             d_params_old, dy0, y0, dy1, y1 = dy
             x0, grad_fn = jax.vjp(base, params, y0, idx)
-            d_params, dx0 = grad_fn(dy1)
+            d_params, dx0, _ = grad_fn(dy1)
             d_params = {k: d_params_old.get(k, 0) + d_params.get(k, 0) for k in d_params.keys()}
             return d_params, dy1, y1 - x0, dx0 + dy0, y0, None
 

--- a/src/model.py
+++ b/src/model.py
@@ -12,6 +12,8 @@ REVERSIBLE_CTX = typing.Tuple[typing.Dict[str, jnp.ndarray], jnp.ndarray, jnp.nd
 
 
 def activate(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
+    if ctx.is_initializing:
+        return inp
     return jax.nn.leaky_relu(inp, ctx.model.leaky_relu_slope)
 
 

--- a/src/model.py
+++ b/src/model.py
@@ -189,9 +189,9 @@ def psum_scatter(inp: jnp.ndarray) -> jnp.ndarray:
 def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typing.Tuple[jnp.ndarray, jnp.ndarray]:
     src = lax.psum(src, ParallelAxes.model)
 
-    max_logit = lax.stop_gradient(src).max(-1)
-    log_z = lax.log(lax.exp(src - max_logit.reshape(tuple(max_logit.shape) + (1,))).sum(-1)) + max_logit
-    loss = (src * one_hot(tgt.astype(src.dtype), src.shape[-1])).sum(-1) - log_z
+    max_logit = lax.stop_gradient(src).max(-1, keepdims=True)
+    log_z = lax.log(lax.exp(src - max_logit).sum(-1, keepdims=True)) + max_logit
+    loss = (src * one_hot(tgt.astype(src.dtype), src.shape[-1])).sum(-1, keepdim=True) - log_z
     loss = -loss.mean()
     accuracy = (jnp.argmax(src, 2) == tgt).astype(jnp.float32).mean()
     if ctx.training.z_loss:

--- a/src/model.py
+++ b/src/model.py
@@ -1,5 +1,4 @@
 import copy
-import math
 import typing
 
 import jax
@@ -196,7 +195,7 @@ def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typi
     loss = loss.mean()
     accuracy = (jnp.argmax(src, 2) == tgt).astype(jnp.float32).mean()
     if ctx.training.z_loss:
-        loss += jnp.square(log_z).mean() * (ctx.training.z_loss / tgt.size)
+        loss += jnp.square(log_z).mean() * ctx.training.z_loss
     return loss, accuracy
 
 

--- a/src/model.py
+++ b/src/model.py
@@ -76,7 +76,6 @@ def conv_block(ctx: Context, inp: jnp.ndarray, idx: jnp.ndarray) -> jnp.ndarray:
     inp = normalize(ctx, inp)
     mid = depthwise_conv(ctx, inp, 1 / ctx.model.activation_std, idx)
     mid = activate(ctx, mid)
-    mid = normalize(ctx, mid)
     return full_conv(ctx, mid, ctx.dims.sizes.depth ** -0.5, idx)
 
 
@@ -99,7 +98,6 @@ def group_feed_forward(ctx: Context, inp: jnp.ndarray, idx: jnp.ndarray) -> jnp.
     inp = normalize(ctx, inp)
     mid = dot(inp, inp_weight, -1, 0, (), ())
     mid = activate(ctx, mid)
-    mid = normalize(ctx, mid)
     out = dot(mid, out_weight, -1, 0, (), ())
     return out
 
@@ -116,7 +114,6 @@ def feed_forward(ctx: Context, inp: jnp.ndarray, idx: jnp.ndarray) -> jnp.ndarra
     mid = dot(inp, inp_weight, -1, 0, (), ())
     mid = lax.psum(mid, ParallelAxes.model)
     mid = activate(ctx, mid)
-    mid = normalize(ctx, mid)
     out = dot(mid, out_weight, -1, 0, (), ())
     return out
 

--- a/src/model.py
+++ b/src/model.py
@@ -198,9 +198,9 @@ def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typi
     src = lax.psum(src, ParallelAxes.model)
 
     max_logit = lax.stop_gradient(src).max(-1, keepdims=True)
-    log_z = lax.log(lax.exp(src - max_logit).sum(-1, keepdims=True)) + max_logit
-    loss = jnp.take_along_axis(src, tgt.reshape(*tgt.shape, 1), -1) - log_z
-    loss = -loss.mean()
+    log_z = lax.log(lax.exp(src - max_logit).sum(-1, keepdims=True)) + max_logit 
+    loss = log_z - jnp.take_along_axis(src, tgt.reshape(*tgt.shape, 1), -1)
+    loss = loss.mean()
     accuracy = (jnp.argmax(src, 2) == tgt).astype(jnp.float32).mean()
     if ctx.training.z_loss:
         loss += jnp.square(log_z).mean() * ctx.training.z_loss

--- a/src/model.py
+++ b/src/model.py
@@ -190,7 +190,7 @@ def cross_entropy_loss(ctx: Context, src: jnp.ndarray, tgt: jnp.ndarray) -> typi
     src = lax.psum(src, ParallelAxes.model)
 
     max_logit = lax.stop_gradient(src).max(-1)
-    log_z = lax.log(lax.exp(src - max_logit).sum(-1)) + max_logit
+    log_z = lax.log(lax.exp(src - max_logit.reshape(tuple(max_logit.shape) + (1,))).sum(-1)) + max_logit
     loss = (src * one_hot(tgt.astype(src.dtype), src.shape[-1])).sum(-1) - log_z
     loss = -loss.mean()
     accuracy = (jnp.argmax(src, 2) == tgt).astype(jnp.float32).mean()

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -68,5 +68,5 @@ def update(ctx: Context, grads: typing.Dict[str, jnp.ndarray], current_step: jnp
         updated_weight = adam(inner_ctx, param_name, grad, current_step)
         parameter_lr = lr * ctx.parameter_variance.get(param_name, 1)
         updated_weight *= parameter_lr
-        updated_weight += (1 - ctx.optimizer.weight_decay * parameter_lr) * ctx.parameters[param_name]
+        updated_weight += (1 + ctx.optimizer.weight_decay * parameter_lr) * ctx.parameters[param_name]
         ctx.parameters[param_name] = updated_weight

--- a/src/utils/checkpoint.py
+++ b/src/utils/checkpoint.py
@@ -1,0 +1,104 @@
+"""
+Adapted from https://github.com/kingoflolz/mesh-transformer-jax/blob/0a75ca9370576ad9d247facf6cb8e9699300e690/mesh_transformer/checkpoint.py
+"""
+
+import functools
+import io
+import multiprocessing
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from smart_open import open
+
+from src.context import Context
+
+pieces = 16  # how many files to split each shard across
+
+
+@functools.partial(jax.jit, backend="cpu")
+def index_weights(weights, idx):
+    cpu_device = jax.devices("cpu")[0]
+    return jax.device_put(jax.tree_map(lambda i: i[idx], weights), cpu_device)
+
+
+def write(x, ckpt_dir):
+    idx, i = x
+    file_path = ckpt_dir + f"{idx}.npz"
+    for _ in range(3):
+        try:
+            with open(file_path, "wb") as f:
+                np.savez(f, *i)
+            return
+        except:
+            print("save failed, trying again")
+
+    print("save failed 3 times, exiting")
+    raise Exception("save failed")
+
+
+def write_ckpt(ctx: Context):
+    flattened, structure = jax.tree_flatten(ctx.parameters)
+
+    for shard in range(ctx.dims.sizes.heads):
+        cpu_flattened = index_weights(flattened, shard)
+
+        k, m = divmod(len(cpu_flattened), pieces)
+        cpu_flattened_chunked = (cpu_flattened[i * k + min(i, m):(i + 1) * k + min(i + 1, m)] for i in range(pieces))
+
+        with multiprocessing.pool.ThreadPool(pieces) as p:
+            write_fn = functools.partial(write, ckpt_dir=f"{ctx.training.checkpoint_path}/")
+            list((p.imap_unordered(write_fn, enumerate(cpu_flattened_chunked))))
+
+
+def read_shard(ckpt_dir):
+    out = []
+    for idx in range(16):
+        file_path = ckpt_dir + f"{idx}.npz"
+        with open(file_path, "rb") as f:
+            buf = f.read()
+            f_io = io.BytesIO(buf)
+            deserialized = np.load(f_io)
+            for i in deserialized:
+                out.append(deserialized[i])
+    return out
+
+
+def read_ckpt(pytree, path, shards_in, load_opt=True):
+    old_flattened, structure = jax.tree_flatten(pytree)
+
+    original_opt_state = pytree["opt_state"]
+
+    with multiprocessing.pool.ThreadPool(shards_in) as p:
+        start = time.time()
+        shards = list((p.imap(read_shard, [f"{path}shard_{i}/" for i in range(shards_in)])))
+        print(f"read from disk/gcs in {time.time() - start:.06}s")
+
+    def _unshard(shards, old_flattened):
+        unsharded = []
+
+        for old, *all_shards in zip(old_flattened, *shards):
+            x = np.stack(all_shards)
+            # No idea why this is V2...?
+            if x.dtype == np.dtype('V2'):
+                x.dtype = jnp.bfloat16
+
+            unsharded.append(x)
+
+            assert x.shape == old.shape, f"Incompatible checkpoints {x.shape} vs {old.shape}"
+        return unsharded
+
+    try:
+        unsharded = _unshard(shards, old_flattened)
+    except AssertionError:
+        load_opt = False  # no opt to load in ckpt
+        del pytree['opt_state']
+        old_flattened, structure = jax.tree_flatten(pytree)
+        unsharded = _unshard(shards, old_flattened)
+
+    loaded_pytree = jax.tree_unflatten(structure, unsharded)
+
+    if not load_opt:
+        loaded_pytree['opt_state'] = original_opt_state
+    return loaded_pytree


### PR DESCRIPTION
This way, we can do custom communication which gives us tons of free room to optimize while also cleaning up the code.\
Instead of calling shard() every other line, we call `psum` (parallel sum/sum across devices) where it's needed. Due to the added freedom, we can also use special ops such as "psum_scatter", which implements the reduce-scatter protocol efficiently and allows us to do things like switching from model-parallel to data-parallel.