### PR TITLE
Chunked Cross-Entropy

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -249,10 +249,6 @@ def input_embed(ctx: Context, inp: jnp.ndarray) -> typing.Tuple[jnp.ndarray, jnp
     return jax.checkpoint(_fn)(inp, param, normalization_scale), param
 
 
-
-
-
-
 def reversible(ctx: Context, fn: typing.Callable[[Context, jnp.ndarray], jnp.ndarray],
                src: REVERSIBLE_CTX) -> REVERSIBLE_CTX:
     if ctx.is_initializing:
@@ -373,10 +369,10 @@ def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.nd
         src = reversible(ctx, pointwise_block, src)
         # src = reversible(ctx, moe, src)
         if i % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1):
-            src = reversible(ctx, qrnn_block, src)  # <-- perhaps use it every N blocks? or less features in RNN?
+            src = reversible(ctx, qrnn_block, src)
     ctx.parameters = src[0]
     out = revnet_out(src[1:])
-    out = scale_norm_act(ctx, src, ctx.dims.features, act=False)
+    out = scale_norm_act(ctx, out, ctx.dims.features, act=False)
     if ctx.is_initializing:
         return out
     return out, wgt

--- a/src/model.py
+++ b/src/model.py
@@ -347,7 +347,7 @@ def cross_entropy_loss(ctx: Context, src_wgt: typing.Tuple[jnp.ndarray, jnp.ndar
         dx = jnp.stack(d_x, axis=1) / tgt.size  # Shape[Features, inp.shape[0] // step, step // devices]
         dx = lax.all_gather(dx, ParallelAxes.model, axis=2).reshape(ctx.dims.sizes.features, -1).transpose(1, 0)
         d_wgt = d_wgt / tgt.size
-        d_wgt = d_wgt.transpose(1, 0).reshape(param.shape)
+        d_wgt = d_wgt.reshape(param.shape)
         dx = dx.reshape(original_shape)
 
         def _grad(dy: typing.Tuple[jnp.ndarray, None]) -> typing.Tuple[jnp.ndarray, None, jnp.ndarray]:


### PR DESCRIPTION
This PR adds chunking to the cross-entropy loss in the output. The convergence is the same as without this PR. However, it allows the training of models with larger vocabularies such as 50256 (GPT-2) or 1048576 (our upcoming tokeniser) tokens without using any more memory.\
The key difficulty in getting this right was that Jax parallelises for loops like
```PYTHON
def loop():
  a = 0
  for i in range(10):
    a += x[i]  # do something memory-expensive with x[i] here
  return a
```
To stop Jax from instantiating all the intermediate values (which we try to avoid using chunking), we must use `jax.lax.scan`.