### PR TITLE
Checkpoint, Restore and Inference

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -1,6 +1,7 @@
 import os
 import typing
 
+import click
 import jax
 import numpy as np
 from jax import lax, numpy as jnp, random
@@ -30,15 +31,16 @@ def body_fn(while_ctx_dict: typing.Dict[str, typing.Any]) -> typing.Dict[str, ty
     temp = jnp.log(temp)
     temp = jnp.negative(temp)
     temp = jnp.log(temp)
-    temp = temp * -wctx.sampling_temperature
+    temp = temp * -wctx.temperature
 
-    # sort = jnp.argsort(out_token)
-    # sort = one_hot(sort, out_token.shape[-1])
-    # sort = jnp.einsum("abcd,c->abd", sort, jnp.arange(out_token.shape[-1]))
-    # top_k_mask = jnp.greater_equal(sort, wctx.top_k)
+    sorted_out, argsort_out = lax.sort_key_val(out_token, lax.broadcasted_iota(jnp.int32, out_token.shape, dimension=2))
+    ranks = jnp.argsort(argsort_out)
+    top_p_mask = jnp.less(jnp.cumsum(jax.nn.softmax(sorted_out)), wctx.top_p)
+    top_k_mask = jnp.greater_equal(ranks, wctx.top_k)
 
     out_token = out_token + temp
-    # out_token = out_token + top_k_mask * -1e9
+    out_token = out_token + top_k_mask * -1e9
+    out_token = out_token + top_p_mask * -1e9
 
     out_token = jnp.argmax(out_token, -1)
     wctx.data = jnp.where(one_hot(wctx.current_step, wctx.ctx.dims.sizes.sequence).reshape(1, -1), out_token, wctx.data)
@@ -47,13 +49,14 @@ def body_fn(while_ctx_dict: typing.Dict[str, typing.Any]) -> typing.Dict[str, ty
 
 
 def jitless_prediction_step(parameters: typing.Dict[str, jnp.ndarray], data: jnp.ndarray,
-                            sampling_temperature: jnp.ndarray, top_k: jnp.ndarray, start_pos: jnp.ndarray,
-                            stop_pos: jnp.ndarray) -> jnp.ndarray:
+                            temperature: jnp.ndarray, top_k: jnp.ndarray, top_p: jnp.ndarray,
+                            start_pos: jnp.ndarray, stop_pos: jnp.ndarray) -> jnp.ndarray:
     wctx = WhilePredictContext()
     wctx.ctx.parameters = parameters
     wctx.data = data
-    wctx.sampling_temperature = sampling_temperature
+    wctx.temperature = temperature
     wctx.top_k = top_k
+    wctx.top_p = top_p
     wctx.start_pos = start_pos
     wctx.stop_pos = stop_pos
     wctx.current_step = jnp.min(start_pos)
@@ -74,31 +77,46 @@ class Inference:
         ctx.is_initializing = False
         partition = {k: 0 for k in ctx.parameters.keys()}
         self.step = jax.pmap(jitless_prediction_step, axis_name=ParallelAxes.model,
-                             in_axes=(partition, None, None, None, None, None), out_axes=None)
+                             in_axes=(partition, None, None, None, None, None, None), out_axes=None)
         self.ctx = ctx
 
-        self.complete_tokens(dummy_data, np.zeros(()), np.ones(()), np.zeros(()), np.ones(()))
+        self.complete_tokens(dummy_data, np.zeros(()), np.ones(()), np.ones(()), np.zeros(()), np.ones(()))
 
-    def complete_tokens(self, prompt: np.array, sampling_temperature: np.array, top_k: np.array, start_pos: np.array,
-                        stop_pos: np.array) -> np.array:
-        return self.step(self.parameters, prompt, sampling_temperature, top_k, start_pos, stop_pos)
+    def complete_tokens(self, prompt: np.array, temperature: np.array, top_k: np.array, top_p: np.array,
+                        start_pos: np.array, stop_pos: np.array) -> np.array:
+        return self.step(self.parameters, prompt, temperature, top_k, top_p, start_pos, stop_pos)
 
-    def complete(self, text: str, sampling_temperature: float = 0.5, top_k: int = 32, length: int = 128):
+    def complete(self, text: str, temperature: float = 0.5, top_k: int = 32, top_p: float = 0.9, length: int = 128):
         tokens = jnp.asarray(np.frombuffer(text.encode(), np.uint8)).astype(jnp.int32).reshape(1, -1)
         tokens = jnp.pad(tokens, ((0, 0), (0, self.ctx.dims.sizes.sequence - len(text))))
         base = jnp.zeros(())
         start = base + len(text)
-        out = self.complete_tokens(tokens, base + sampling_temperature, base + top_k, start, start + length)[0]
+        out = self.complete_tokens(tokens, base + temperature, base + top_k, base + top_p, start, start + length)[0]
         return np.asarray(out).astype(np.uint8).tobytes().decode(errors='ignore')[len(text):len(text) + length]
 
 
-def main():
+@click.command()
+@click.option('--temperature', default=0.5, type=float,
+              help="Sampling temperature. Higher -> wider distribution / more random")
+@click.option('--top-k', default=32, type=int, help="Across how many of the top tokens should be sampled")
+@click.option('--top-p', default=1, type=float, help="How much probability mass to sample from")
+@click.option('--length', default=128, type=int, help="Number of tokens to generate")
+def interactive(temperature: float, top_k: int, top_p: float, length: int):
     model = Inference(Context())
     while True:
         prompt = input(">>> ")
-        out = model.complete(prompt)
+        out = model.complete(prompt, temperature, top_k, top_p, length)
         print(out, "-" * os.get_terminal_size().columns, sep='\n')
 
 
-if __name__ == '__main__':
-    main()
+@click.command()
+@click.option('--prompt', help="Text to feed into the language model.")
+@click.option('--temperature', default=0.5, type=float,
+              help="Sampling temperature. Higher -> wider distribution / more random")
+@click.option('--top-k', default=32, type=int, help="Across how many of the top tokens should be sampled")
+@click.option('--top-p', default=1, type=float, help="How much probability mass to sample from")
+@click.option('--length', default=128, type=int, help="Number of tokens to generate")
+def once(prompt: str, temperature: float, top_k: int, top_p: float, length: int):
+    model = Inference(Context())
+    out = model.complete(prompt, temperature, top_k, top_p, length)
+    print(out, "-" * os.get_terminal_size().columns, sep='\n')

--- a/inference.py
+++ b/inference.py
@@ -44,10 +44,9 @@ def body_fn(while_ctx_dict: typing.Dict[str, typing.Any]) -> typing.Dict[str, ty
     top_k_mask = jnp.less(ranks, wctx.top_k)
 
     cumulative_probabilities = jnp.cumsum(jax.nn.softmax(sorted_out), -1)
-    overflow = jnp.argmax(jnp.greater(cumulative_probabilities, wctx.top_p), -1, keepdims=True)  # overflow index
-    top_p_mask = jnp.arange(wctx.ctx.dims.sizes.vocab).reshape(1, 1, -1) > overflow  # to shift by 1
-    top_p_mask = jnp.take_along_axis(top_p_mask, ranks, axis=2)
-
+    overflow = jnp.greater(cumulative_probabilities, wctx.top_p)
+    overflow = jnp.concatenate([jnp.zeros_like(cumulative_probabilities[:, :, :1]), overflow], -1)
+    top_p_mask = jnp.take_along_axis(overflow, ranks, axis=2)
     out_token = out_token + temp
     out_token = out_token + (top_k_mask + top_p_mask) * -1e9
 

--- a/inference.py
+++ b/inference.py
@@ -172,7 +172,12 @@ class RestAPI:
         return await self.decode((await self.token_completion(params)).token_completion)
 
 
-@click.command()
+@click.group()
+def main():
+    pass
+
+
+@main.command()
 def api():
     rest_api = RestAPI()
     fast_api = FastAPI()
@@ -186,7 +191,7 @@ def api():
     uvicorn.run(fast_api, host='0.0.0.0', port=62220, log_level='info', workers=1)
 
 
-@click.command()
+@main.command()
 @click.option('--temperature', default=0.5, type=float,
               help="Sampling temperature. Higher -> wider distribution / more random")
 @click.option('--top-k', default=32, type=int, help="Across how many of the top tokens should be sampled")
@@ -200,7 +205,7 @@ def interactive(temperature: float, top_k: int, top_p: float, length: int):
         print(out, "-" * os.get_terminal_size().columns, sep='\n')
 
 
-@click.command()
+@main.command()
 @click.option('--prompt', help="Text to feed into the language model.")
 @click.option('--temperature', default=0.5, type=float,
               help="Sampling temperature. Higher -> wider distribution / more random")
@@ -211,3 +216,7 @@ def once(prompt: str, temperature: float, top_k: int, top_p: float, length: int)
     model = Inference(Context())
     out = model.complete(prompt, temperature, top_k, top_p, length)
     print(out, "-" * os.get_terminal_size().columns, sep='\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/inference.py
+++ b/inference.py
@@ -84,7 +84,7 @@ class Inference:
                              in_axes=(partition, None, None, None, None, None, None), out_axes=None)
         self.ctx = ctx
 
-        self.complete_tokens(dummy_data, np.zeros(()), np.ones(()), np.ones(()), np.zeros(()), np.ones(()))
+        self.complete_jax(dummy_data, np.zeros(()), np.ones(()), np.ones(()), np.zeros(()), np.ones(()))
 
     def complete_jax(self, prompt: np.array, temperature: np.array, top_k: np.array, top_p: np.array,
                      start_pos: np.array, stop_pos: np.array) -> np.array:

--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -3,7 +3,7 @@ sudo apt install -y libpq-dev python-dev python3-dev gcc libgl1-mesa-glx ffmpeg 
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade "jax[tpu]>=0.3.0" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 sudo python3 -m pip uninstall tensorboard tbp-nightly tb-nightly tensorboard-plugin-profile -y
-python3 -m pip install wandb smart-open jsonpickle tpunicorn google-api-python-client google-cloud-tpu redis sqlalchemy psycopg2-binary opencv-python Pillow git+https://github.com/ytdl-org/youtube-dl.git google-cloud-storage oauth2client utils scipy gdown omegaconf pyparsing==2.4.7 einops pytorch-lightning
+python3 -m pip install wandb smart-open jsonpickle tpunicorn google-api-python-client google-cloud-tpu redis sqlalchemy psycopg2-binary opencv-python Pillow git+https://github.com/ytdl-org/youtube-dl.git google-cloud-storage oauth2client utils scipy gdown omegaconf pyparsing==2.4.7 einops pytorch-lightning fastapi uvicorn pydantic
 python3 -m pip install --upgrade --force-reinstall tensorflow==2.8.0
 git clone https://github.com/CompVis/taming-transformers
 mv taming-transformers script/

--- a/src/context.py
+++ b/src/context.py
@@ -1,5 +1,5 @@
 import copy
-import sys
+import os
 import typing
 
 import yaml
@@ -192,8 +192,8 @@ class Context(DataClass):
         self.dims = Dims(self.data)
         self.dims.sizes.intermediate = self.dims.sizes.features * 2
 
-        if len(sys.argv) > 1 and sys.argv[1].endswith('.yaml'):
-            with open(sys.argv[1]) as f:
+        if 'CONFIG' in os.environ:
+            with open(os.environ['CONFIG']) as f:
                 cfg = f.read()
             init_class(self, yaml.safe_load(cfg))
 

--- a/src/context.py
+++ b/src/context.py
@@ -284,6 +284,7 @@ class WhilePredictContext(WhileContext):
         self.temperature = jnp.zeros([batch_dim_size])
         self.top_k = jnp.array([vocab_dim_size] * batch_dim_size)
         self.top_p = jnp.array([1] * batch_dim_size)
+        self.seed = jnp.array([0] * batch_dim_size)
 
         if self.config is not None:
             self.start_pos = config['start_pos']
@@ -291,6 +292,7 @@ class WhilePredictContext(WhileContext):
             self.temperature = config['temperature']
             self.top_k = config['top_k']
             self.top_p = config['top_p']
+            self.ctx.seed = config['seed']
 
     def serialize(self):
         serialized = self._serialize()
@@ -299,5 +301,6 @@ class WhilePredictContext(WhileContext):
         serialized['temperature'] = self.temperature
         serialized['top_k'] = self.top_k
         serialized['top_p'] = self.top_p
+        serialized['seed'] = self.ctx.seed
 
         return serialized

--- a/src/context.py
+++ b/src/context.py
@@ -281,20 +281,23 @@ class WhilePredictContext(WhileContext):
 
         self.start_pos = jnp.zeros([batch_dim_size])
         self.stop_pos = jnp.array([sequence_dim_size] * batch_dim_size)[0]
-        self.sampling_temperature = jnp.zeros([batch_dim_size])
+        self.temperature = jnp.zeros([batch_dim_size])
         self.top_k = jnp.array([vocab_dim_size] * batch_dim_size)
+        self.top_p = jnp.array([1] * batch_dim_size)
 
         if self.config is not None:
             self.start_pos = config['start_pos']
             self.stop_pos = config['stop_pos']
-            self.sampling_temperature = config['sampling_temperature']
+            self.temperature = config['temperature']
             self.top_k = config['top_k']
+            self.top_p = config['top_p']
 
     def serialize(self):
         serialized = self._serialize()
         serialized['start_pos'] = self.start_pos
         serialized['stop_pos'] = self.stop_pos
-        serialized['sampling_temperature'] = self.sampling_temperature
+        serialized['temperature'] = self.temperature
         serialized['top_k'] = self.top_k
+        serialized['top_p'] = self.top_p
 
         return serialized

--- a/src/inference.py
+++ b/src/inference.py
@@ -23,7 +23,7 @@ def body_fn(while_ctx_dict: typing.Dict[str, typing.Any]) -> typing.Dict[str, ty
 
     out, wgt = body_ctx(wctx.ctx, wctx.data)
     out = (out * one_hot(wctx.current_step - 1, wctx.ctx.dims.sizes.sequence).reshape(1, -1, 1)).sum(1, keepdims=True)
-    out_token = matmul(out, wgt.transpose(1, 0)).reshape(out.shape[0], 1, -1)
+    out_token = lax.psum(matmul(out, wgt.transpose(1, 0)).reshape(out.shape[0], 1, -1), ParallelAxes.model)
 
     key = random.PRNGKey((wctx.ctx.seed + wctx.current_step).astype(jnp.int32))
     temp = random.uniform(key, out_token.shape, maxval=1, minval=1e-7, dtype=jnp.float32)

--- a/src/inference.py
+++ b/src/inference.py
@@ -30,14 +30,15 @@ def body_fn(while_ctx_dict: typing.Dict[str, typing.Any]) -> typing.Dict[str, ty
     temp = jnp.log(temp)
     temp = jnp.negative(temp)
     temp = jnp.log(temp)
-    temp = temp * wctx.sampling_temperature
-    out_token = out_token + temp
+    temp = temp * -wctx.sampling_temperature
 
     # sort = jnp.argsort(out_token)
     # sort = one_hot(sort, out_token.shape[-1])
     # sort = jnp.einsum("abcd,c->abd", sort, jnp.arange(out_token.shape[-1]))
     # top_k_mask = jnp.greater_equal(sort, wctx.top_k)
-    # out_token = out_token + top_k_mask * 1e-9
+
+    out_token = out_token + temp
+    # out_token = out_token + top_k_mask * -1e9
 
     out_token = jnp.argmax(out_token, -1)
     wctx.data = jnp.where(one_hot(wctx.current_step, wctx.ctx.dims.sizes.sequence).reshape(1, -1), out_token, wctx.data)

--- a/src/inference.py
+++ b/src/inference.py
@@ -23,8 +23,8 @@ def body_fn(while_ctx_dict: typing.Dict[str, typing.Any]) -> typing.Dict[str, ty
 
     one_hot_mask = one_hot(wctx.current_step, wctx.ctx.dims.sizes.sequence).reshape(1, -1)
     out, wgt = body_ctx(wctx.ctx, wctx.data)
-    out = (out * one_hot_mask).sum(1, keepdims=True)
-    out_token = matmul(out, wgt.transpose(1, 0))
+    out = (out * one_hot_mask.reshape(1, -1, 1)).sum(1, keepdims=True)
+    out_token = matmul(out, wgt.transpose(1, 0)).reshape(out.shape[0], 1, -1)
 
     key = random.PRNGKey((wctx.ctx.seed + wctx.current_step).astype(jnp.int32))
     temp = random.uniform(key, out_token.shape, maxval=1, minval=1e-7, dtype=jnp.float32)

--- a/src/inference.py
+++ b/src/inference.py
@@ -9,6 +9,7 @@ from src.constants import ParallelAxes
 from src.context import Context, WhilePredictContext
 from src.main import get_parameters
 from src.model import body_ctx, one_hot
+from src.backend import matmul
 from src.utils.checkpoint import read_ckpt
 
 
@@ -20,8 +21,10 @@ def cond_fn(while_ctx_dict: typing.Dict[str, typing.Any]) -> bool:
 def body_fn(while_ctx_dict: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
     wctx = WhilePredictContext(while_ctx_dict)
 
-    one_hot_mask = one_hot(wctx.current_step, wctx.ctx.dims.sizes.sequence)
-    out_token = body_ctx(wctx.ctx, wctx.data)
+    one_hot_mask = one_hot(wctx.current_step, wctx.ctx.dims.sizes.sequence).reshape(1, -1)
+    out, wgt = body_ctx(wctx.ctx, wctx.data)
+    out = (out * one_hot_mask).sum(1, keepdims=True)
+    out_token = matmul(out, wgt.transpose(1, 0))
 
     key = random.PRNGKey((wctx.ctx.seed + wctx.current_step).astype(jnp.int32))
     temp = random.uniform(key, out_token.shape, maxval=1, minval=1e-7, dtype=jnp.float32)

--- a/src/main.py
+++ b/src/main.py
@@ -152,7 +152,8 @@ def run_one(wblog: typing.Optional[WandbLog] = None):
                 jax.profiler.start_trace(ctx.training.trace.output_path)
             if idx == ctx.training.trace.stop_step:
                 jax.profiler.stop_trace()
-        if ctx.training.do_checkpoint and (idx + 1) % ctx.training.checkpoint_interval == 0:
+        if ctx.training.do_checkpoint \
+                and (idx + 1) % (ctx.training.checkpoint_interval // ctx.training.device_steps) == 0:
             write_ckpt(ctx)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,6 @@
 import copy
 import math
-import sys
+import os
 import time
 import typing
 import warnings
@@ -159,7 +159,7 @@ def run_one(wblog: typing.Optional[WandbLog] = None):
 def dump_ctx(ctx: Context, run):
     with open("config.yaml", 'w') as f:
         f.write(yaml.dump(ctx.config(), indent=4))
-    sys.argv.insert(1, "config.yaml")
+    os.environ['CONFIG'] = 'config.yaml'
     run.config.update(ctx.config(), allow_val_change=True)
 
 

--- a/src/utils/checkpoint.py
+++ b/src/utils/checkpoint.py
@@ -45,9 +45,10 @@ def write_ckpt(ctx: Context):
 
     structure = str(structure)  # like "PyTreeDef({'2': {'a': *}})"
     structure = structure.replace('PyTreeDef', '')[1:-1]  # clean up "types"
-    structure = structure.replace(': *', ': null').replace("{'", '{"').replace("':", '":')  # to valid JSON
+    structure = structure.replace(': *', ': null').replace("{'", '{"').replace("':", '":')
+    structure = structure.replace("', ", '", ').replace(", '", ', "')  # to valid JSON
 
-    with open(f"{ctx.training.checkpoint_path}/structure.pkl", "w") as f:
+    with open(f"{ctx.training.checkpoint_path}/structure.json", "w") as f:
         f.write(structure)
 
     for shard in range(ctx.dims.sizes.heads):
@@ -84,7 +85,7 @@ def read_ckpt(ctx: Context, ignore: str = '.*optimizer.*'):
     old_flattened, structure = jax.tree_flatten(ctx.parameters)
     ignore = re.compile(ignore)
 
-    with open(f"{ctx.training.checkpoint_path}/structure.pkl", "w") as f:
+    with open(f"{ctx.training.checkpoint_path}/structure.json", "r") as f:
         new_structure = f.read()
     new_structure = json.loads(new_structure)
     new_structure = deep_replace(new_structure, jnp.zeros((1,)))

--- a/src/utils/checkpoint.py
+++ b/src/utils/checkpoint.py
@@ -82,7 +82,6 @@ def deep_replace(d, value):
 
 
 def read_ckpt(ctx: Context, ignore: str = '.*optimizer.*'):
-    old_flattened, structure = jax.tree_flatten(ctx.parameters)
     ignore = re.compile(ignore)
 
     with open(f"{ctx.training.checkpoint_path}/structure.json", "r") as f:

--- a/src/utils/checkpoint.py
+++ b/src/utils/checkpoint.py
@@ -97,7 +97,7 @@ def read_ckpt(ctx: Context, ignore: str = '.*optimizer.*'):
         print(f"read from disk/gcs in {time.time() - start:.06}s")
 
     unsharded = []
-    for old, *all_shards in zip(old_flattened, *shards):
+    for all_shards in zip(*shards):
         x = np.stack(all_shards)
         if x.dtype == np.dtype('V2'):
             x.dtype = jnp.bfloat16


### PR DESCRIPTION
We can now save and restore the structure of an arbitrary Jax PyTree.
```PYTHON
>>> example_pytree = jax.tree_util.tree_flatten({'2':{'a':jax.numpy.ones((256,))}})[1]
>>> str(example_pytree)
"PyTreeDef({'2': {'a': *}})"
>>> (txt := str(example_pytree).replace('PyTreeDef', '')[1:-1].replace(': *', ': null').replace("{'", '{"').replace("':", '":').replace("', ", '", ').replace(", '", ', "'))
'{"2": {"a": null}}'
>>> # text is now dumpable as text and can be reloaded as json using stdlib
>>> (d := json.loads(txt))
{'2': {'a': None}}
>>> (d := deep_replace(d, jnp.zeros((1,)))
{'2': {'a': DeviceArray([0.], dtype=float32)}}
>>> jax.tree_util.tree_flatten(arr)[1]   # get the original tree
PyTreeDef({'2': {'a': *}})
```
We can restore an original model without storing its config or recreating its parameters. Similarly, we can load a checkpoint and continue training without instantiating new optimiser parameters that we would only replace. Dumping PyTrees improves efficiency and elegance while allowing for adaptive filtering of weights and insertion into new structures without manually aligning them.

Other than that, the fixes are non-issues. The checkpoint/restore code is tested, and an evaluation model is currently being trained.