### PR TITLE
Scan

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -53,14 +53,6 @@ def tuple_int(obj: INT_OR_TUPLE) -> typing.Sequence[int]:
     raise ValueError
 
 
-def sum_pool(inputs: jnp.ndarray, window_shape: typing.List[int],
-             padding: typing.List[typing.Tuple[int, int]]) -> jnp.ndarray:
-    strides = (1,) * (len(window_shape) + 2)
-    dims = (1,) + tuple(window_shape) + (1,)
-    padding = ((0, 0),) + tuple(padding) + ((0, 0),)
-    return lax.reduce_window(inputs, 0, lax.add, dims, strides, padding)
-
-
 def is_stacked(ctx: Context, param_name: str, val: jnp.ndarray):
     return val.shape[0] == ctx.dims.depth and "/step:" in param_name and 'optimizer' not in param_name
 

--- a/src/backend.py
+++ b/src/backend.py
@@ -61,6 +61,10 @@ def sum_pool(inputs: jnp.ndarray, window_shape: typing.List[int],
     return lax.reduce_window(inputs, 0, lax.add, dims, strides, padding)
 
 
+def is_stacked(ctx: Context, param_name: str, val: jnp.ndarray):
+    return val.shape[0] == ctx.dims.depth and "/step:" in param_name and 'optimizer' not in param_name
+
+
 def conv(inp: jnp.ndarray, weight: jnp.ndarray, padding: typing.List[typing.Tuple[int, int]], groups: int):
     ndim = weight.ndim
     lhs = (0, ndim - 1) + tuple(range(1, ndim - 1))

--- a/src/backend.py
+++ b/src/backend.py
@@ -63,8 +63,8 @@ def sum_pool(inputs: jnp.ndarray, window_shape: typing.List[int],
 
 def conv(inp: jnp.ndarray, weight: jnp.ndarray, padding: typing.List[typing.Tuple[int, int]], groups: int):
     ndim = weight.ndim
-    dimension_numbers = (0, ndim - 1) + tuple(range(1, ndim - 1))
-    dimension_numbers = lax.ConvDimensionNumbers(dimension_numbers, tuple(range(ndim)), dimension_numbers)
+    lhs = (0, ndim - 1) + tuple(range(1, ndim - 1))
+    dimension_numbers = lax.ConvDimensionNumbers(lhs, (0, ndim - 1,) + tuple(range(1, ndim - 1)), lhs)
     return lax.conv_general_dilated(inp, weight, (1,) * (ndim - 2), padding=padding, feature_group_count=groups,
                                     dimension_numbers=dimension_numbers, precision='fastest')
 

--- a/src/backend.py
+++ b/src/backend.py
@@ -123,6 +123,9 @@ def get_param(ctx: Context, name: str, shape: typing.Optional[typing.List[int]] 
         computation_dtype = dtype
         storage_dtype = dtype
 
+    if ctx.add_depth:
+        shape = [ctx.dims.batch] + list(shape)
+
     if prefix_name not in ctx.parameters:
         if init_val is not None:
             param = init_val * scale * post_variance_scale

--- a/src/backend.py
+++ b/src/backend.py
@@ -54,7 +54,7 @@ def tuple_int(obj: INT_OR_TUPLE) -> typing.Sequence[int]:
 
 
 def is_stacked(ctx: Context, param_name: str, val: jnp.ndarray):
-    return val.shape[0] == ctx.dims.depth and "/step:" in param_name and 'optimizer' not in param_name
+    return val.shape[0] == ctx.dims.depth and "/step:" in param_name and '/optimizer' not in param_name
 
 
 def conv(inp: jnp.ndarray, weight: jnp.ndarray, padding: typing.List[typing.Tuple[int, int]], groups: int):

--- a/src/context.py
+++ b/src/context.py
@@ -219,6 +219,7 @@ class Context(DataClass):
         self.parameter_variance: typing.Dict[str, float] = {}
         self.prng_key = random.PRNGKey(self.seed)
         self.is_initializing = False
+        self.add_depth = False
 
         if config is not None:
             self.__dict__.update(config)

--- a/src/context.py
+++ b/src/context.py
@@ -143,6 +143,7 @@ class Optimizer(DataClass):
 
 
 class Model(DataClass):
+    unroll_depth: int = 1
     conv_scale: float = 4.
     conv_shift: float = 8.
     norm_eps: float = 1e-16

--- a/src/context.py
+++ b/src/context.py
@@ -81,7 +81,6 @@ class Dims(DataClass):
     moe_intermediate: int = 4096
     heads: int = jax.device_count()
     sequence: int = 4096
-    one: int = 1
     depth: int = 16
 
     def __init__(self, data: DataContext):
@@ -117,13 +116,9 @@ class Optimizer(DataClass):
     nesterov: bool = True
     heavyball: bool = True
     graft_to_adam: bool = False
-    use_shampoo: bool = True
     block_size: int = 512
     epsilon: float = 1e-16
-    start_preconditioning_step: int = 16
-    preconditioning_compute_steps: int = 128
     statistics_compute_steps: int = 4
-    skip_preconditioning_dim_size_gt: int = 1024
     momentum_beta: float = 0.1
     learning_rate: float = 0.01
     gradient_clip: float = 0.001
@@ -148,9 +143,6 @@ class Model(DataClass):
     conv_shift: float = 8.
     norm_eps: float = 1e-16
     qrnn_frequency: int = 8
-    rezero_lr_scale: float = 0.01
-    leaky_relu_slope: float = 0.01
-    activation_std: float = 0.5893595616022745
     storage_dtype: str = "float32"  # valid jax.numpy.dtype
     computation_dtype: str = "bfloat16"
 

--- a/src/context.py
+++ b/src/context.py
@@ -65,6 +65,7 @@ class DataContext(DataClass):
     interleaved_datasets: int = 2
     prefetch_buffer: int = 2
     seed: int = 0
+    deterministic: bool = True
     vocab_size: int = 256  # should be divisible by 128
     datasets_used_per_step: int = 2
 

--- a/src/data.py
+++ b/src/data.py
@@ -1,3 +1,4 @@
+import os
 import random
 import typing
 
@@ -11,7 +12,7 @@ from .context import Context
 tf1 = tf.compat.v1
 
 
-def decoder(int_string: bool, data: tf.Tensor, seed: int, context_p1: int, sub_batch: int):
+def decoder(int_string: bool, data: tf.Tensor, seed: int, context_p1: int, sub_batch: int, deterministic: bool):
     """
     Read a given tfrecord and windowed text dataset out of it.
     :param int_string: whether the entire dataset is in int64 or byte
@@ -19,6 +20,7 @@ def decoder(int_string: bool, data: tf.Tensor, seed: int, context_p1: int, sub_b
     :param seed: rng seed
     :param context_p1: context + 1
     :param sub_batch: number of samples should be taken from this dataset per batch
+    :param deterministic: whether to use sloppy interleave (fast) or deterministic interleave (slow)
     :return: tensorflow dataset of tokens
     """
     batch_prod = context_p1 * sub_batch
@@ -39,7 +41,7 @@ def decoder(int_string: bool, data: tf.Tensor, seed: int, context_p1: int, sub_b
         dat = tf.reshape(dat, (-1, batch_prod))
         return tf.data.Dataset.from_tensor_slices(dat)
 
-    return tf.data.TFRecordDataset(filenames=data).interleave(chunk, cycle_length=1, deterministic=False)
+    return tf.data.TFRecordDataset(filenames=data).interleave(chunk, cycle_length=1, deterministic=deterministic)
 
 
 def debug_generator(ctx: Context) -> typing.Iterator[np.ndarray]:
@@ -82,17 +84,19 @@ def text_dataset(ctx: Context) -> typing.Iterator[np.ndarray]:
         return x
 
     dset = dset.interleave(lambda x: decoder('int64' in filenames[0], x, rng.randint(0, 2 ** 32),
-                                             sequence_length_1, full_batch // ctx.data.datasets_used_per_step),
+                                             sequence_length_1, full_batch // ctx.data.datasets_used_per_step,
+                                             ctx.data.deterministic),
                            cycle_length=ctx.data.interleaved_datasets,
                            num_parallel_calls=ctx.data.parallel_workers,
-                           deterministic=False)
+                           deterministic=ctx.data.deterministic)
     if ctx.data.shuffle_buffer > 0:
         dset = dset.shuffle(ctx.data.shuffle_buffer, seed=rng.randint(0, 2 ** 32))
-    dset = dset.batch(ctx.data.datasets_used_per_step, deterministic=False).map(_slice_target, deterministic=False)
+    dset = dset.batch(ctx.data.datasets_used_per_step, deterministic=ctx.data.deterministic)
+    dset = dset.map(_slice_target, deterministic=ctx.data.deterministic)
     if ctx.data.prefetch_buffer > 0:
         dset = dset.prefetch(ctx.data.prefetch_buffer)
     options = tf.data.Options()
-    options.deterministic = False
+    options.deterministic = ctx.data.deterministic
     options.experimental_optimization.apply_default_optimizations = True
     options.experimental_optimization.filter_fusion = True
     options.experimental_optimization.map_and_batch_fusion = True
@@ -102,8 +106,8 @@ def text_dataset(ctx: Context) -> typing.Iterator[np.ndarray]:
     options.experimental_optimization.noop_elimination = True
     options.experimental_optimization.parallel_batch = True
     options.experimental_optimization.shuffle_and_repeat_fusion = True
-    options.threading.private_threadpool_size = 96
-    options.experimental_slack = True
+    options.threading.private_threadpool_size = os.cpu_count()
+    options.experimental_slack = not ctx.data.deterministic
     options.experimental_distribute.auto_shard_policy = AutoShardPolicy.AUTO
     dset = dset.with_options(options)
     return dset.as_numpy_iterator()

--- a/src/model/conv.py
+++ b/src/model/conv.py
@@ -12,7 +12,7 @@ def conv(ctx: Context, inp: jnp.ndarray, conv_kernel: int, scale: float, in_feat
     fan_in = (1 - 1 / (conv_kernel * ctx.model.conv_scale + ctx.model.conv_shift)) ** fan_in
     fan_in = fan_in / fan_in.sum()
     fan_in = fan_in.reshape(1, 1, -1)
-    weight = get_param(ctx, "weight", [out_features, in_features, conv_kernel], column_axes=2, scale=scale,
+    weight = get_param(ctx, "weight", [out_features, conv_kernel, in_features], column_axes=2, scale=scale,
                        lr_scale=fan_in)
     if ctx.is_initializing:
         return jnp.zeros(inp.shape[:-1] + (out_features,))

--- a/src/model/conv.py
+++ b/src/model/conv.py
@@ -16,7 +16,7 @@ def conv(ctx: Context, inp: jnp.ndarray, conv_kernel: int, scale: float, in_feat
                        lr_scale=fan_in)
     if ctx.is_initializing:
         return jnp.zeros(inp.shape[:-1] + (out_features,))
-    return lax_conv(inp, weight, [(weight.shape[-1] - 1, 0)], 1)
+    return lax_conv(inp, weight, [(conv_kernel - 1, 0)], 1)
 
 
 @prenorm

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -32,11 +32,12 @@ def step(ctx: Context):
         ctx.name_cache = copy.deepcopy(name_cache)
         ctx.parameters = params
         src = [params] + list(carry)
-        src = reversible(ctx, pointwise_block, src)
-        src = reversible(ctx, bottleneck_block, src)
-        src = reversible(ctx, pointwise_block, src)
-        # src = lax.cond(idx % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1),
-        #                lambda s: reversible(ctx, qrnn_block, s), lambda s: s, src)
+        for depth in range(ctx.model.qrnn_frequency):
+            src = reversible(ctx, pointwise_block, src)
+            src = reversible(ctx, bottleneck_block, src)
+            src = reversible(ctx, pointwise_block, src)
+            if depth % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1):
+                src = reversible(ctx, qrnn_block, s)  # lax.cond could work but requires work on the parameter store
         if ctx.is_initializing:
             return params
 

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -9,6 +9,7 @@ from src.context import Context
 from src.model.conv import bottleneck_block, pointwise_block
 from src.model.loss import cross_entropy_loss
 from src.model.norm import scale_norm_act
+from src.model.qrnn import qrnn_block
 from src.model.reversible import FourArrays, reversible, revnet_out
 
 

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -58,7 +58,7 @@ def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.nd
     if ctx.is_initializing:
         ctx.parameters = step(ctx)(src, ({}, 0))
     else:
-        src, _ = step(ctx)(src, ({}, 0))
+        src, _ = step(ctx)(src, (ctx.parameters, 0))
     out = revnet_out(src)
     out = scale_norm_act(ctx, out, ctx.dims.features, act=False)
     wgt = get_param(ctx, "out_embd", [ctx.dims.features, ctx.dims.vocab], std=1,

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -9,7 +9,7 @@ from src.model.conv import bottleneck_block, pointwise_block
 from src.model.loss import cross_entropy_loss
 from src.model.norm import scale_norm_act
 from src.model.qrnn import qrnn_block
-from src.model.reversible import FourArrays, reversible, revnet_out
+from src.model.reversible import reversible, revnet_out
 
 
 @with_context()
@@ -23,36 +23,24 @@ def input_embed(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
     return jax.checkpoint(_fn)(inp, param)
 
 
-@with_context()
-def step(ctx: Context):
-    def _fn(carry: FourArrays, x: typing.Tuple[typing.Dict[str, jnp.ndarray], jnp.ndarray]):
-        params, idx = x
-        src = [params] + list(carry)
-        for _ in range(ctx.model.unroll_depth):
-            for depth in range(ctx.model.qrnn_frequency):
-                src = reversible(ctx, pointwise_block, src)
-                src = reversible(ctx, bottleneck_block, src)
-                src = reversible(ctx, pointwise_block, src)
-                if depth % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1):
-                    src = reversible(ctx, qrnn_block, src)
-                    # lax.cond could work but requires work on the parameter store
-        if ctx.is_initializing:
-            return src[0]
-
-        return src[1:], None
-
-    return _fn
-
-
 def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
     src = input_embed(ctx, src)
     zero = jnp.zeros_like(src)
     src = (src, zero, src, zero)
+
+    src = [ctx.parameters] + list(src)
+    for _ in range(ctx.model.unroll_depth):
+        for depth in range(ctx.model.qrnn_frequency):
+            src = reversible(ctx, pointwise_block, src)
+            src = reversible(ctx, bottleneck_block, src)
+            src = reversible(ctx, pointwise_block, src)
+            if depth % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1):
+                src = reversible(ctx, qrnn_block, src)
+                # lax.cond could work but requires work on the parameter store
     if ctx.is_initializing:
-        ctx.parameters = step(ctx)(src, ({}, 0))
-    else:
-        src, _ = step(ctx)(src, (ctx.parameters, 0))
-    out = revnet_out(src)
+        ctx.parameters = src[0]
+
+    out = revnet_out(src[1:])
     out = scale_norm_act(ctx, out, ctx.dims.features, act=False)
     wgt = get_param(ctx, "out_embd", [ctx.dims.features, ctx.dims.vocab], std=1,
                     lr_scale=ctx.optimizer.output_scale, scale=1 / ctx.dims.heads)

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -9,7 +9,7 @@ from src.model.conv import bottleneck_block, pointwise_block
 from src.model.loss import cross_entropy_loss
 from src.model.norm import scale_norm_act
 from src.model.qrnn import qrnn_block
-from src.model.reversible import reversible, revnet_out
+from src.model.reversible import FourArrays, reversible, revnet_out
 
 
 @with_context()
@@ -23,24 +23,36 @@ def input_embed(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
     return jax.checkpoint(_fn)(inp, param)
 
 
+@with_context()
+def step(ctx: Context):
+    def _fn(carry: FourArrays, x: typing.Tuple[typing.Dict[str, jnp.ndarray], jnp.ndarray]):
+        params, idx = x
+        src = [params] + list(carry)
+        for _ in range(ctx.model.unroll_depth):
+            for depth in range(ctx.model.qrnn_frequency):
+                src = reversible(ctx, pointwise_block, src)
+                src = reversible(ctx, bottleneck_block, src)
+                src = reversible(ctx, pointwise_block, src)
+                if depth % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1):
+                    src = reversible(ctx, qrnn_block, src)
+                    # lax.cond could work but requires work on the parameter store
+        if ctx.is_initializing:
+            return src[0]
+
+        return src[1:], None
+
+    return _fn
+
+
 def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
     src = input_embed(ctx, src)
     zero = jnp.zeros_like(src)
     src = (src, zero, src, zero)
-
-    src = [ctx.parameters] + list(src)
-    for _ in range(ctx.model.unroll_depth):
-        for depth in range(ctx.model.qrnn_frequency):
-            src = reversible(ctx, pointwise_block, src)
-            src = reversible(ctx, bottleneck_block, src)
-            src = reversible(ctx, pointwise_block, src)
-            if depth % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1):
-                src = reversible(ctx, qrnn_block, src)
-                # lax.cond could work but requires work on the parameter store
     if ctx.is_initializing:
-        ctx.parameters = src[0]
-
-    out = revnet_out(src[1:])
+        ctx.parameters = step(ctx)(src, ({}, 0))
+    else:
+        src, _ = step(ctx)(src, (ctx.parameters, 0))
+    out = revnet_out(src)
     out = scale_norm_act(ctx, out, ctx.dims.features, act=False)
     wgt = get_param(ctx, "out_embd", [ctx.dims.features, ctx.dims.vocab], std=1,
                     lr_scale=ctx.optimizer.output_scale, scale=1 / ctx.dims.heads)

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -38,7 +38,7 @@ def step(ctx: Context):
             src = reversible(ctx, bottleneck_block, src)
             src = reversible(ctx, pointwise_block, src)
             if depth % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1):
-                src = reversible(ctx, qrnn_block, s)  # lax.cond could work but requires work on the parameter store
+                src = reversible(ctx, qrnn_block, src)  # lax.cond could work but requires work on the parameter store
         if ctx.is_initializing:
             return params
 

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -26,7 +26,7 @@ def input_embed(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
 def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
     src = input_embed(ctx, src)
     zero = jnp.zeros_like(src)
-    src = (src, zero, src, zero)
+    src = (ctx.parameters, src, zero, src, zero)
     for i in range(ctx.dims.depth):
         src = reversible(ctx, pointwise_block, src)
         src = reversible(ctx, bottleneck_block, src)

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -23,6 +23,7 @@ def input_embed(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
     return jax.checkpoint(_fn)(inp, param)
 
 
+@with_context()
 def step(ctx: Context):
     def _fn(carry: FourArrays, params: typing.Dict[str, jnp.ndarray]):
         original_parameters = ctx.parameters

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -33,12 +33,13 @@ def step(ctx: Context):
         ctx.name_cache = copy.deepcopy(name_cache)
         ctx.parameters = params
         src = [params] + list(carry)
-        for depth in range(ctx.model.qrnn_frequency):
-            src = reversible(ctx, pointwise_block, src)
-            src = reversible(ctx, bottleneck_block, src)
-            src = reversible(ctx, pointwise_block, src)
-            if depth % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1):
-                src = reversible(ctx, qrnn_block, src)  # lax.cond could work but requires work on the parameter store
+        for _ in range(ctx.model.unroll_depth):
+            for depth in range(ctx.model.qrnn_frequency):
+                src = reversible(ctx, pointwise_block, src)
+                src = reversible(ctx, bottleneck_block, src)
+                src = reversible(ctx, pointwise_block, src)
+                if depth % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1):
+                    src = reversible(ctx, qrnn_block, src)  # lax.cond could work but requires work on the parameter store
         if ctx.is_initializing:
             return params
 

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -1,4 +1,3 @@
-import copy
 import typing
 
 import jax
@@ -38,7 +37,7 @@ def step(ctx: Context):
                     src = reversible(ctx, qrnn_block, src)
                     # lax.cond could work but requires work on the parameter store
         if ctx.is_initializing:
-            return params
+            return src[0]
 
         return src[1:], None
 

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -45,7 +45,7 @@ def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.nd
     src = (src, zero, src, zero)
     if ctx.is_initializing:
         ctx.add_depth = True
-        src = step(ctx)(src, ({}, 0))
+        src, _ = step(ctx)(src, ({}, 0))
         ctx.add_depth = False
     else:
         params = {p: k for p, k in ctx.parameters.items() if 'optimizer' not in p and k.shape[0] == ctx.dims.depth}

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -1,3 +1,4 @@
+import copy
 import typing
 
 import jax
@@ -9,7 +10,7 @@ from src.model.conv import bottleneck_block, pointwise_block
 from src.model.loss import cross_entropy_loss
 from src.model.norm import scale_norm_act
 from src.model.qrnn import qrnn_block
-from src.model.reversible import reversible, revnet_out
+from src.model.reversible import FourArrays, reversible, revnet_out
 
 
 @with_context()
@@ -23,17 +24,44 @@ def input_embed(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
     return jax.checkpoint(_fn)(inp, param)
 
 
+@with_context()
+def step(ctx: Context):
+    name_cache = copy.deepcopy(ctx.name_cache)
+
+    def _fn(carry: FourArrays, x: typing.Tuple[typing.Dict[str, jnp.ndarray], jnp.ndarray]):
+        params, idx = x
+        ctx.name_cache = copy.deepcopy(name_cache)
+        ctx.parameters = params
+        src = [params] + list(carry)
+        for _ in range(ctx.model.unroll_depth):
+            for depth in range(ctx.model.qrnn_frequency):
+                src = reversible(ctx, pointwise_block, src)
+                src = reversible(ctx, bottleneck_block, src)
+                src = reversible(ctx, pointwise_block, src)
+                if depth % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1):
+                    src = reversible(ctx, qrnn_block,
+                                     src)  # lax.cond could work but requires work on the parameter store
+        if ctx.is_initializing:
+            return params
+
+        ctx.parameters = None
+        ctx.name_cache = name_cache
+        return src[1:], None
+
+    return _fn
+
+
 def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
     src = input_embed(ctx, src)
     zero = jnp.zeros_like(src)
-    src = (ctx.parameters, src, zero, src, zero)
-    for i in range(ctx.dims.depth):
-        src = reversible(ctx, pointwise_block, src)
-        src = reversible(ctx, bottleneck_block, src)
-        src = reversible(ctx, pointwise_block, src)
-        if i % ctx.model.qrnn_frequency == (ctx.model.qrnn_frequency // 2 - 1):
-            src = reversible(ctx, qrnn_block, src)
-    out = revnet_out(src[1:])
+    src = (src, zero, src, zero)
+    if ctx.is_initializing:
+        ctx.add_depth = True
+        ctx.parameters = step(ctx)(src, ({}, 0))
+        ctx.add_depth = False
+    else:
+        src, _ = step(ctx)(src, ({}, 0))
+    out = revnet_out(src)
     out = scale_norm_act(ctx, out, ctx.dims.features, act=False)
     wgt = get_param(ctx, "out_embd", [ctx.dims.features, ctx.dims.vocab], std=1,
                     lr_scale=ctx.optimizer.output_scale, scale=1 / ctx.dims.heads)

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -47,7 +47,7 @@ def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.nd
     zero = jnp.zeros_like(src)
     src = (src, zero, src, zero)
     if ctx.is_initializing:
-        ctx.parameters = step(ctx)(src, {})
+        ctx.parameters = step(ctx)(src, ctx.parameters)
     else:
         src, _ = step(ctx)(src, ctx.parameters)
     out = revnet_out(src)

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -56,9 +56,7 @@ def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.nd
     zero = jnp.zeros_like(src)
     src = (src, zero, src, zero)
     if ctx.is_initializing:
-        ctx.add_depth = True
         ctx.parameters = step(ctx)(src, ({}, 0))
-        ctx.add_depth = False
     else:
         src, _ = step(ctx)(src, ({}, 0))
     out = revnet_out(src)

--- a/src/model/moe.py
+++ b/src/model/moe.py
@@ -87,7 +87,7 @@ def top1_gating(ctx: Context, gate: jnp.ndarray, x: jnp.ndarray) -> typing.Tuple
 @with_context()
 def moe(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
     inp_wgt = get_param(ctx, "ff_input", [ctx.dims.features, ctx.dims.moe_intermediate],
-                        scale=1 / ctx.model.activation_std, lr_scale=ctx.optimizer.moe_scale)
+                        lr_scale=ctx.optimizer.moe_scale)
     out_wgt = get_param(ctx, "ff_output", [ctx.dims.moe_intermediate, ctx.dims.features],
                         lr_scale=ctx.optimizer.moe_scale)
 

--- a/src/model/qrnn.py
+++ b/src/model/qrnn.py
@@ -1,6 +1,7 @@
 import math
 
 import jax
+import numpy as np
 from jax import lax, numpy as jnp
 
 from src.backend import promote_to, with_context
@@ -11,9 +12,9 @@ from src.model.norm import prenorm, scale_norm_act
 
 def qrnn(forget: jnp.ndarray, x: jnp.ndarray) -> jnp.ndarray:
     dtype = forget.dtype
-    for i in range(int(math.log2(x.shape[1]))):
-        x = x.at[:, 2 ** i:].add(x[:, :-2 ** i] * forget[:, 2 ** i:])
-        forget = forget.at[:, 2 ** i:].mul(forget[:, :-2 ** i])
+    for offset in 2 ** np.arange(int(math.log2(x.shape[1]))):
+        x = x.at[:, offset:].add(x[:, :-offset] * forget[:, offset:])
+        forget = forget.at[:, offset:].mul(forget[:, :-offset])
     return x.astype(dtype)
 
 

--- a/src/model/qrnn.py
+++ b/src/model/qrnn.py
@@ -9,11 +9,11 @@ from src.model.conv import conv
 from src.model.norm import prenorm, scale_norm_act
 
 
-def qrnn(ctx: Context, forget: jnp.ndarray, x: jnp.ndarray) -> jnp.ndarray:
+def qrnn(forget: jnp.ndarray, x: jnp.ndarray) -> jnp.ndarray:
     dtype = forget.dtype
-    for i in range(int(math.log2(ctx.dims.sequence))):
-        x += jnp.concatenate([jnp.zeros((x.shape[0], 2 ** i, x.shape[2])), x[:, :-2 ** i] * forget[:, 2 ** i:]], 1)
-        forget *= jnp.concatenate([jnp.ones((x.shape[0], 2 ** i, x.shape[2])), forget[:, :-2 ** i]], 1)
+    for i in range(int(math.log2(x.shape[1]))):
+        x = x.at[:, 2 ** i:].add(x[:, :-2 ** i] * forget[:, 2 ** i:])
+        forget = forget.at[:, 2 ** i:].mul(forget[:, :-2 ** i])
     return x.astype(dtype)
 
 
@@ -24,7 +24,7 @@ def qrnn_grad(ctx: Context, forget: jnp.ndarray, src: jnp.ndarray) -> jnp.ndarra
     @jax.custom_gradient
     def _fn(fgt: jnp.ndarray, inp: jnp.ndarray):
         dtype = inp.dtype
-        out = qrnn(ctx, jax.nn.hard_sigmoid(promote_to(fgt, jnp.float32)), promote_to(inp, jnp.float32))
+        out = qrnn(jax.nn.hard_sigmoid(promote_to(fgt, jnp.float32)), promote_to(inp, jnp.float32))
         out = out.astype(dtype)
 
         def _grad(dy: jnp.ndarray):
@@ -33,7 +33,7 @@ def qrnn_grad(ctx: Context, forget: jnp.ndarray, src: jnp.ndarray) -> jnp.ndarra
             f = lax.rev(f, (1,))
             f = jnp.concatenate([jnp.ones((x.shape[0], 1, x.shape[2])), f[:, :-1]], 1)
             dy_rev = lax.rev(dy, (1,))
-            dx = lax.rev(qrnn(ctx, f, dy_rev), (1,))
+            dx = lax.rev(qrnn(f, dy_rev), (1,))
             df = dx * promote_to(out, jnp.float32)
             df = jnp.where(jnp.logical_or(fgt > 3, fgt < -3), 0, df / 6)
             df = df.astype(dtype)

--- a/src/model/reversible.py
+++ b/src/model/reversible.py
@@ -7,10 +7,9 @@ from jax import numpy as jnp
 from src.context import Context
 
 REVERSIBLE_CTX = typing.Tuple[typing.Dict[str, jnp.ndarray], jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]
+ReversibleFn = typing.Callable[[Context, jnp.ndarray], jnp.ndarray]
 
-
-def reversible(ctx: Context, fn: typing.Callable[[Context, jnp.ndarray], jnp.ndarray],
-               src: REVERSIBLE_CTX) -> REVERSIBLE_CTX:
+def reversible(ctx: Context, fn: ReversibleFn, src: REVERSIBLE_CTX) -> REVERSIBLE_CTX:
     if ctx.is_initializing:
         params, _x00, x01, x10, x11 = src
         new_ctx = ctx.add_to_prefix("reversible")

--- a/src/model/reversible.py
+++ b/src/model/reversible.py
@@ -8,6 +8,8 @@ from src.context import Context
 
 REVERSIBLE_CTX = typing.Tuple[typing.Dict[str, jnp.ndarray], jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]
 ReversibleFn = typing.Callable[[Context, jnp.ndarray], jnp.ndarray]
+FourArrays = typing.Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]
+
 
 def reversible(ctx: Context, fn: ReversibleFn, src: REVERSIBLE_CTX) -> REVERSIBLE_CTX:
     if ctx.is_initializing:
@@ -46,10 +48,10 @@ def reversible(ctx: Context, fn: ReversibleFn, src: REVERSIBLE_CTX) -> REVERSIBL
     return _fn(*src)
 
 
-def revnet_out(src: typing.Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]) -> jnp.ndarray:
+def revnet_out(src: FourArrays) -> jnp.ndarray:
     @jax.custom_gradient
     def _fn(x0: jnp.ndarray, _x0_back: jnp.ndarray, x1: jnp.ndarray, _x1_back: jnp.ndarray):
-        def _grad(dy) -> typing.Tuple[jnp.ndarray, jnp.ndarray, None, jnp.ndarray]:
+        def _grad(dy) -> FourArrays:
             return dy, x0, dy, x1
 
         return x0 + x1, _grad

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -3,7 +3,7 @@ import typing
 import jax
 from jax import lax, numpy as jnp
 
-from .backend import assign, get_param, prefixed_name, stable_rsqrt, with_context, zero_param
+from .backend import assign, get_param, is_stacked, prefixed_name, stable_rsqrt, with_context, zero_param
 from .context import Context
 from .shampoo import Preconditioner, fallback_pth_root
 
@@ -97,10 +97,6 @@ def shampoo(ctx: Context, grad: jnp.ndarray, step: jnp.ndarray) -> jnp.ndarray: 
 def grafted_shampoo(ctx: Context, weight_update: jnp.ndarray, grad: jnp.ndarray, step: jnp.ndarray) -> jnp.ndarray:
     shampoo_update = shampoo(ctx, grad, step)
     return graft(weight_update, shampoo_update)
-
-
-def is_stacked(ctx: Context, param_name: str, val: jnp.ndarray):
-    return val.shape[0] == ctx.dims.depth and "/step:" in param_name
 
 
 def clip_norm(ctx: Context, param_name: str, val: jnp.ndarray, min_norm: float) -> jnp.ndarray:

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -104,7 +104,7 @@ def is_stacked(ctx: Context, val: jnp.ndarray):
 def clip_norm(ctx: Context, val: jnp.ndarray, min_norm: float) -> jnp.ndarray:
     val = lax.square(val)
     if is_stacked(ctx, val):
-        val = val.sum(tuple(range(1, val.ndim)))
+        val = val.sum(tuple(range(1, val.ndim))).reshape((-1,) + (1,) * val.ndim)
     else:
         val = val.sum()
     return jnp.maximum(jnp.sqrt(val), min_norm)

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -104,7 +104,7 @@ def is_stacked(ctx: Context, val: jnp.ndarray):
 def clip_norm(ctx: Context, val: jnp.ndarray, min_norm: float) -> jnp.ndarray:
     val = lax.square(val)
     if is_stacked(ctx, val):
-        val = val.sum(tuple(range(1, val.ndim))).reshape((-1,) + (1,) * val.ndim)
+        val = val.sum(tuple(range(1, val.ndim))).reshape((-1,) + (1,) * (val.ndim - 1))
     else:
         val = val.sum()
     return jnp.maximum(jnp.sqrt(val), min_norm)

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -91,13 +91,28 @@ def shampoo(ctx: Context, grad: jnp.ndarray, step: jnp.ndarray) -> jnp.ndarray: 
     return preconditioner.preconditioned_grad(grad, new_preconditioners)
 
 
-def clip_norm(val: jnp.ndarray, min_norm: float) -> jnp.ndarray:
-    return jnp.maximum(jnp.sqrt(jnp.square(val).sum()), min_norm)
+@with_context(count=False)
+def grafted_shampoo(ctx: Context, weight_update: jnp.ndarray, grad: jnp.ndarray, step: jnp.ndarray) -> jnp.ndarray:
+    shampoo_update = shampoo(ctx, grad, step)
+    return graft(weight_update, shampoo_update)
+
+
+def is_stacked(ctx: Context, val: jnp.ndarray):
+    return val.shape[0] == ctx.dims.depth
+
+
+def clip_norm(ctx: Context, val: jnp.ndarray, min_norm: float) -> jnp.ndarray:
+    val = lax.square(val)
+    if is_stacked(ctx, val):
+        val = val.sum(tuple(range(1, val.ndim)))
+    else:
+        val = val.sum()
+    return jnp.maximum(jnp.sqrt(val), min_norm)
 
 
 def adaptive_gradient_clipping(ctx: Context, param_name: str, grad: jnp.ndarray) -> jnp.ndarray:
-    grd_norm = clip_norm(grad, ctx.optimizer.epsilon)
-    wgt_norm = clip_norm(ctx.parameters[param_name], 1e-3)
+    grd_norm = clip_norm(ctx, grad, ctx.optimizer.epsilon)
+    wgt_norm = clip_norm(ctx, ctx.parameters[param_name], 1e-3)
     grad_scale = jnp.minimum(wgt_norm / grd_norm * ctx.optimizer.gradient_clip, 1)
     return grad * grad_scale
 
@@ -123,20 +138,25 @@ def update(ctx: Context, grads: typing.Dict[str, jnp.ndarray], step: jnp.ndarray
         if "optimizer" in param_name:
             continue
         ctx = outer_ctx.add_to_prefix(param_name, count=False)
-        parameter_lr = lr * ctx.parameter_variance.get(param_name, 1)
-        grad = grad.astype(jnp.float64)
+        if grad.shape[0] == ctx.dims.depth:
+            parameter_lr = lr * ctx.parameter_variance.get(param_name, 1)
+            grad = grad.astype(jnp.float64)
 
-        grad = adaptive_gradient_clipping(ctx, param_name, grad)
+            grad = adaptive_gradient_clipping(ctx, param_name, grad)
 
-        if small_parameter(param_name, grad) or ctx.optimizer.graft_to_adam:  # Do adam update for small parameters
-            weight_update = adam(ctx, grad, step)
-        else:
-            weight_update = sm3(ctx, grad)
-        if not small_parameter(param_name, grad):
-            if ctx.optimizer.use_shampoo:
-                shampoo_update = shampoo(ctx, grad, step)
-                weight_update = graft(weight_update, shampoo_update)
-            weight_update = ema(ctx, weight_update, step, 1 - ctx.optimizer.momentum_beta)
-            ctx.parameters[param_name] = (1 + ctx.optimizer.weight_decay * parameter_lr) * ctx.parameters[param_name]
-        weight_update = weight_update.astype(ctx.parameters[param_name].dtype)
-        ctx.parameters[param_name] = weight_update * parameter_lr + ctx.parameters[param_name]
+            if small_parameter(param_name, grad) or ctx.optimizer.graft_to_adam:  # Do adam update for small parameters
+                weight_update = adam(ctx, grad, step)
+            else:
+                weight_update = sm3(ctx, grad)
+            if not small_parameter(param_name, grad):
+                if ctx.optimizer.use_shampoo:
+                    if is_stacked(ctx, grad):
+                        weight_update = jnp.stack([grafted_shampoo(ctx, weight_update, grad[i], step)
+                                                   for i in range(grad.shape[0])], 0)
+                    else:
+                        weight_update = grafted_shampoo(ctx, weight_update, grad, step)
+                weight_update = ema(ctx, weight_update, step, 1 - ctx.optimizer.momentum_beta)
+                ctx.parameters[param_name] = (1 + ctx.optimizer.weight_decay * parameter_lr) * ctx.parameters[
+                    param_name]
+            weight_update = weight_update.astype(ctx.parameters[param_name].dtype)
+            ctx.parameters[param_name] = weight_update * parameter_lr + ctx.parameters[param_name]

--- a/train_watcher.py
+++ b/train_watcher.py
@@ -48,7 +48,7 @@ def parse_args():
     parser.add_argument("--branch", type=str, default="main", help="Branch on github to use")
     parser.add_argument("--slices", default=1, type=int,
                         help="How many TPU slices each TPU should have (1=>vX-8, 4=>vX-32)")
-    parser.add_argument("--storage-prefix", type=str, help="Storage prefix to use for all runs on WandB")
+    parser.add_argument("--storage-prefix", type=str, help="Storage prefix to use for weights on gcloud bucket")
     parser.add_argument("--config-path", type=str, help="Path to config.yaml")
     parser.add_argument("--cleanup", default=0, type=int,
                         help="Instead of running something new, kill all tpus. 1 or 0 for y/n")


### PR DESCRIPTION
The compilation time is down from 600s (depth=32, qrnn_frequency=8) to 70s (depth=4, qrnn_frequency=8 -> total_depth=4*8). 

Baseline: <https://wandb.ai/homebrewnlp/gpt/runs/2ar16xdkjoz57mdvgipffnng335nik6t>\
New: <https://wandb.ai/homebrewnlp/gpt/runs/4hqwsrq7o9ic8x2bhp3wgu7ipdhk1h3y>

Once #7 is finished and we run QRNN at every step, the compile time will drop as we don't have to manually unroll 8 steps anymore.