### PR TITLE
LpNorm + ScaleNorm

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -37,8 +37,8 @@ def is_main():
     return jax.process_index() == 0
 
 
-def stable_rsqrt(inp: jnp.ndarray, eps: float) -> jnp.ndarray:
-    return jnp.reciprocal(jnp.maximum(jnp.sqrt(jnp.maximum(inp, 0)), eps))
+def stable_rsqrt(inp: jnp.ndarray, eps: float, power: float = 2) -> jnp.ndarray:
+    return jnp.reciprocal(jnp.maximum(jnp.power(jnp.maximum(inp, 0), 1 / power), eps))
 
 
 def pos_dim(inp: jnp.ndarray, dims: typing.Sequence[int]) -> typing.Sequence[int]:

--- a/src/context.py
+++ b/src/context.py
@@ -111,6 +111,16 @@ class WandB(DataClass):
     median_sizes: typing.List[int] = [64, 256, 1024]
 
 
+class Scale(DataClass):
+    qrnn: float = 1
+    moe: float = 1
+    input: float = 1
+    output: float = 1
+    bottleneck: float = 1
+    pointwise: float = 1
+    norm: float = 1
+
+
 class Optimizer(DataClass):
     nesterov: bool = True
     heavyball: bool = True
@@ -127,13 +137,7 @@ class Optimizer(DataClass):
     weight_decay: float = 0.01
     warmup_end: int = 16384
     exponential_decay: float = 3e-6
-    norm_scale: float = 1
-    bottleneck_scale: float = 1
-    pointwise_scale: float = 1
-    qrnn_scale: float = 1
-    moe_scale: float = 1
-    input_scale: float = 1
-    output_scale: float = 1
+    scale: Scale = Scale()
 
 
 class Normalization(DataClass):

--- a/src/context.py
+++ b/src/context.py
@@ -136,15 +136,19 @@ class Optimizer(DataClass):
     output_scale: float = 1
 
 
+class Normalization(DataClass):
+    power: int = 1  # Lp-Norm, like sum(abs(x)^p). Default: 2, as in standard deviation from LayerNorm/ScaleNorm
+    zero_mean: bool = False  # A bit slower, but LayerNorm+BatchNorm do it
+    eps: float = 1e-16
+
+
 class Model(DataClass):
+    norm: Normalization = Normalization()
     autoregressive: bool = True
     unroll_depth: int = 1
     conv_scale: float = 4.
     conv_shift: float = 8.
-    norm_eps: float = 1e-16
     qrnn_frequency: int = 8
-    norm_power: int = 1  # Lp-Norm, like sum(abs(x)^p). Default: 2, as in standard deviation from LayerNorm/ScaleNorm
-    normalize_mean: bool = False  # A bit slower, but LayerNorm+BatchNorm do it
     storage_dtype: str = "float32"  # valid jax.numpy.dtype
     computation_dtype: str = "bfloat16"
     mixer_iterations: int = 2  # ideally spatial_mixing_kernel ** mixer_iterations > sequence_length

--- a/src/context.py
+++ b/src/context.py
@@ -143,6 +143,7 @@ class Model(DataClass):
     conv_shift: float = 8.
     norm_eps: float = 1e-16
     qrnn_frequency: int = 8
+    norm_power: int = 1  # Lp-Norm, like sum(abs(x)^p). Default: 2, as in standard deviation from LayerNorm/ScaleNorm
     storage_dtype: str = "float32"  # valid jax.numpy.dtype
     computation_dtype: str = "bfloat16"
     mixer_iterations: int = 2  # ideally spatial_mixing_kernel ** mixer_iterations > sequence_length

--- a/src/context.py
+++ b/src/context.py
@@ -141,7 +141,7 @@ class Optimizer(DataClass):
 
 
 class Normalization(DataClass):
-    power: int = 1  # Lp-Norm, like sum(abs(x)^p). Default: 2, as in standard deviation from LayerNorm/ScaleNorm
+    power: int = 2  # Lp-Norm, like sum(abs(x)^p). Default: 2, as in standard deviation from LayerNorm/ScaleNorm
     zero_mean: bool = False  # A bit slower, but LayerNorm+BatchNorm do it
     eps: float = 1e-16
 

--- a/src/context.py
+++ b/src/context.py
@@ -144,6 +144,7 @@ class Model(DataClass):
     norm_eps: float = 1e-16
     qrnn_frequency: int = 8
     norm_power: int = 1  # Lp-Norm, like sum(abs(x)^p). Default: 2, as in standard deviation from LayerNorm/ScaleNorm
+    normalize_mean: bool = False  # A bit slower, but LayerNorm+BatchNorm do it
     storage_dtype: str = "float32"  # valid jax.numpy.dtype
     computation_dtype: str = "bfloat16"
     mixer_iterations: int = 2  # ideally spatial_mixing_kernel ** mixer_iterations > sequence_length

--- a/src/model/conv.py
+++ b/src/model/conv.py
@@ -22,21 +22,21 @@ def conv(ctx: Context, inp: jnp.ndarray, conv_kernel: int, scale: float, in_feat
 @prenorm
 @with_context()
 def bottleneck_block(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
-    inp = conv(ctx, inp, ctx.dims.outer_bottleneck_kernel, ctx.optimizer.bottleneck_scale,
+    inp = conv(ctx, inp, ctx.dims.outer_bottleneck_kernel, ctx.optimizer.scale.bottleneck,
                ctx.dims.features, ctx.dims.inner_bottleneck_features)
     inp = scale_norm_act(ctx, inp, ctx.dims.inner_bottleneck_features, psum=True)
-    inp = conv(ctx, inp, ctx.dims.inner_bottleneck_kernel, ctx.optimizer.bottleneck_scale,
+    inp = conv(ctx, inp, ctx.dims.inner_bottleneck_kernel, ctx.optimizer.scale.bottleneck,
                ctx.dims.inner_bottleneck_features, ctx.dims.inner_bottleneck_features)
     inp = scale_norm_act(ctx, inp, ctx.dims.inner_bottleneck_features)
-    return conv(ctx, inp, ctx.dims.outer_bottleneck_kernel, ctx.optimizer.bottleneck_scale,
+    return conv(ctx, inp, ctx.dims.outer_bottleneck_kernel, ctx.optimizer.scale.bottleneck,
                 ctx.dims.inner_bottleneck_features, ctx.dims.features)
 
 
 @prenorm
 @with_context()
 def dense_block(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
-    inp = conv(ctx, inp, ctx.dims.pointwise_kernel, ctx.optimizer.pointwise_scale, ctx.dims.features,
+    inp = conv(ctx, inp, ctx.dims.pointwise_kernel, ctx.optimizer.scale.pointwise, ctx.dims.features,
                ctx.dims.pointwise_features)
     inp = activate(inp)
-    return conv(ctx, inp, ctx.dims.pointwise_kernel, ctx.optimizer.pointwise_scale, ctx.dims.pointwise_features,
+    return conv(ctx, inp, ctx.dims.pointwise_kernel, ctx.optimizer.scale.pointwise, ctx.dims.pointwise_features,
                 ctx.dims.features)

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -15,7 +15,7 @@ from src.model.reversible import FourArrays, reversible, revnet_out
 @with_context()
 def input_embed(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
     param = get_param(ctx, "inp_embd", [ctx.dims.vocab, ctx.dims.features], std=1 / ctx.dims.features,
-                      lr_scale=ctx.optimizer.input_scale)
+                      lr_scale=ctx.optimizer.scale.input)
 
     def _fn(src: jnp.ndarray, wgt: jnp.ndarray) -> jnp.ndarray:
         return jnp.take(wgt, src, 0)
@@ -56,7 +56,7 @@ def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.nd
     out = revnet_out(src)
     out = scale_norm_act(ctx, out, ctx.dims.features, act=False)
     wgt = get_param(ctx, "out_embd", [ctx.dims.features, ctx.dims.vocab], std=1,
-                    lr_scale=ctx.optimizer.output_scale, scale=1 / ctx.dims.heads)
+                    lr_scale=ctx.optimizer.scale.output, scale=1 / ctx.dims.heads)
     if ctx.is_initializing:
         return out
     return out, wgt

--- a/src/model/moe.py
+++ b/src/model/moe.py
@@ -87,11 +87,11 @@ def top1_gating(ctx: Context, gate: jnp.ndarray, x: jnp.ndarray) -> typing.Tuple
 @with_context()
 def moe(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
     inp_wgt = get_param(ctx, "ff_input", [ctx.dims.features, ctx.dims.moe_intermediate],
-                        lr_scale=ctx.optimizer.moe_scale)
+                        lr_scale=ctx.optimizer.scale.moe)
     out_wgt = get_param(ctx, "ff_output", [ctx.dims.moe_intermediate, ctx.dims.features],
-                        lr_scale=ctx.optimizer.moe_scale)
+                        lr_scale=ctx.optimizer.scale.moe)
 
-    gates = conv(ctx, inp, ctx.dims.pointwise_kernel, ctx.optimizer.moe_scale, ctx.dims.features, ctx.dims.features)
+    gates = conv(ctx, inp, ctx.dims.pointwise_kernel, ctx.optimizer.scale.moe, ctx.dims.features, ctx.dims.features)
     mid, indices = top1_gating(ctx, gates, inp)
     mid = matmul(mid, inp_wgt)
     mid = activate(mid)

--- a/src/model/norm.py
+++ b/src/model/norm.py
@@ -26,6 +26,8 @@ def norm_forward(ctx: Context, src: jnp.ndarray, wgt: typing.Optional[jnp.ndarra
     src_fp64 = promote_to(src, run_type)
     if psum:
         src_fp64 = lax.psum(src_fp64, axis_name=ParallelAxes.model)
+    if ctx.model.normalize_mean:
+        src_fp64 -= src_fp64.mean(-1, keepdims=True)
     std = stable_rsqrt(jnp.power(jnp.abs(src_fp64), ctx.model.norm_power).sum(-1, keepdims=True), ctx.model.norm_eps,
                        ctx.model.norm_power)
     norm_out = src_fp64 * std
@@ -33,7 +35,7 @@ def norm_forward(ctx: Context, src: jnp.ndarray, wgt: typing.Optional[jnp.ndarra
     if act:
         out = activate_forward(out)
     out = out.astype(original_dtype)
-    src_fp64 = src_fp64.astype(original_dtype) if psum else src
+    src_fp64 = src_fp64.astype(original_dtype) if ctx.model.normalize_mean or psum else src
     return out, src_fp64, std
 
 
@@ -73,6 +75,8 @@ def scale_norm_act(ctx: Context, inp: jnp.ndarray, feature_dim: int, weight: typ
             if ctx.model.norm_power % 2 != 0:  # x^1, x^3 need to be made non-negative; x^2, x^4 don't
                 d_std *= lax.sign(src_fp64)
             dx = dy * std - d_std
+            if ctx.model.normalize_mean:
+                dx -= dx.mean(-1, keepdims=True)
             if psum:
                 dx = lax.psum(dx, axis_name=ParallelAxes.model)
             return dx.astype(original_dtype), d_wgt

--- a/src/model/norm.py
+++ b/src/model/norm.py
@@ -31,8 +31,8 @@ def norm_forward(ctx: Context, src: jnp.ndarray, wgt: typing.Optional[jnp.ndarra
     out = norm_out * wgt.reshape((1,) * (src.ndim - 1) + (-1,))
     if act:
         out = activate_forward(out)
-    out = out.astype(original_dtype)
-    src_fp64 = src_fp64.astype(original_dtype)
+    #out = out.astype(original_dtype)
+    #   src_fp64 = src_fp64.astype(original_dtype)
     return out, src_fp64, std
 
 
@@ -66,10 +66,8 @@ def scale_norm_act(ctx: Context, inp: jnp.ndarray, feature_dim: int, weight: typ
             if act:
                 dy = dy * activate_grad(norm_out_fp64 * reshaped_weight)
             d_wgt = (dy * norm_out_fp64).sum(list(range(src.ndim - 1))).reshape((-1,))
-            square = jnp.square(src_fp64)
-            sqsum = square.sum(-1, keepdims=True)
-            square = sqsum - square
-            dy = dy * reshaped_weight * square * std / sqsum
+            sqsum = jnp.square(src_fp64).sum(-1, keepdims=True)
+            dy = dy * reshaped_weight * (sqsum - src_fp64 * src_fp64.sum(-1, keepdims=True)) * lax.pow(sqsum, -3 / 2)
             if psum:
                 dy = lax.psum(dy, axis_name=ParallelAxes.model)
             return dy.astype(original_dtype), d_wgt

--- a/src/model/norm.py
+++ b/src/model/norm.py
@@ -67,7 +67,7 @@ def scale_norm_act(ctx: Context, inp: jnp.ndarray, feature_dim: int, weight: typ
                 dy = dy * activate_grad(norm_out_fp64 * reshaped_weight)
             d_wgt = (dy * norm_out_fp64).sum(list(range(src.ndim - 1))).reshape((-1,))
             dy = dy * reshaped_weight * std
-            dy -= (dy * norm_out_fp64).mean(-1, keepdims=True) * norm_out_fp64 * src.shape[-1]
+            dy -= (dy * norm_out_fp64).sum(-1, keepdims=True) * norm_out_fp64
             if psum:
                 dy = lax.psum(dy, axis_name=ParallelAxes.model)
             return dy.astype(original_dtype), d_wgt

--- a/src/model/norm.py
+++ b/src/model/norm.py
@@ -26,15 +26,13 @@ def norm_forward(ctx: Context, src: jnp.ndarray, wgt: typing.Optional[jnp.ndarra
     src_fp64 = promote_to(src, run_type)
     if psum:
         src_fp64 = lax.psum(src_fp64, axis_name=ParallelAxes.model)
-    mean = src_fp64.mean(-1, keepdims=True)
-    std = stable_rsqrt(jnp.square(src_fp64).sum(-1, keepdims=True) - src.shape[-1] * jnp.square(mean),
-                       ctx.model.norm_eps)
-    norm_out = (src_fp64 - mean) * std
+    std = stable_rsqrt(jnp.square(src_fp64).sum(-1, keepdims=True), ctx.model.norm_eps)
+    norm_out = src_fp64 * std
     out = norm_out * wgt.reshape((1,) * (src.ndim - 1) + (-1,))
     if act:
         out = activate_forward(out)
     out = out.astype(original_dtype)
-    return out, norm_out, std
+    return out, norm_out
 
 
 @with_context()
@@ -55,7 +53,7 @@ def scale_norm_act(ctx: Context, inp: jnp.ndarray, feature_dim: int, weight: typ
     @jax.custom_gradient
     def _fn(src: jnp.ndarray, wgt: jnp.ndarray):
         original_dtype = src.dtype
-        out, norm_out, std = norm_forward(ctx, src, wgt, psum, act)
+        out, norm_out = norm_forward(ctx, src, wgt, psum, act)
 
         def _grad(dy: jnp.ndarray) -> typing.Tuple[jnp.ndarray, jnp.ndarray]:
             norm_out_fp64 = promote_to(norm_out, run_type)
@@ -64,9 +62,9 @@ def scale_norm_act(ctx: Context, inp: jnp.ndarray, feature_dim: int, weight: typ
             if act:
                 dy = dy * activate_grad(norm_out_fp64 * reshaped_weight)
             d_wgt = (dy * norm_out_fp64).sum(list(range(src.ndim - 1))).reshape((-1,))
-            dy = dy * std * reshaped_weight
-            dy -= (dy * norm_out_fp64).mean(-1, keepdims=True) * norm_out_fp64 * src.shape[-1]  # "undo" l2norm
-            dy -= dy.mean(-1, keepdims=True)
+            square = jnp.square(norm_out)
+            square = square.sum(-1, keepdims=True) - square
+            dy = dy * lax.integer_pow(std, 3) * reshaped_weight * square
             if psum:
                 dy = lax.psum(dy, axis_name=ParallelAxes.model)
             return dy.astype(original_dtype), d_wgt

--- a/src/model/norm.py
+++ b/src/model/norm.py
@@ -49,7 +49,7 @@ def scale_norm_act(ctx: Context, inp: jnp.ndarray, feature_dim: int, weight: typ
             # 1 otherwise to make sure model can learn
             init_mean = float(not bool(ctx.training.checkpoint_load_path))
         weight = get_param(ctx, "scale", [feature_dim], std=0, mean=init_mean, dtype=run_type,
-                           lr_scale=ctx.optimizer.norm_scale)
+                           lr_scale=ctx.optimizer.scale.norm)
 
     if ctx.is_initializing:
         return inp

--- a/src/model/qrnn.py
+++ b/src/model/qrnn.py
@@ -51,10 +51,10 @@ def qrnn_grad(ctx: Context, forget: jnp.ndarray, src: jnp.ndarray) -> jnp.ndarra
 def qrnn_block(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
     # 500ms at 256 features (forward pass, backward takes slightly longer)
     # While conv 256->256 with kernel_size=5 takes ~11.3ms
-    mid = conv(ctx, inp, ctx.dims.pointwise_kernel, ctx.optimizer.qrnn_scale, ctx.dims.features,
+    mid = conv(ctx, inp, ctx.dims.pointwise_kernel, ctx.optimizer.scale.qrnn, ctx.dims.features,
                ctx.dims.inner_bottleneck_features * 2)
     mid, forget = jnp.split(mid, 2, -1)
     out = qrnn_grad(ctx, forget, mid)
     out = scale_norm_act(ctx, out, ctx.dims.inner_bottleneck_features)
-    return conv(ctx, out, ctx.dims.pointwise_kernel, ctx.optimizer.qrnn_scale, ctx.dims.inner_bottleneck_features,
+    return conv(ctx, out, ctx.dims.pointwise_kernel, ctx.optimizer.scale.qrnn, ctx.dims.inner_bottleneck_features,
                 ctx.dims.features)

--- a/unittests/grad/activation.py
+++ b/unittests/grad/activation.py
@@ -3,11 +3,11 @@ from jax import numpy as jnp
 
 from src.context import Context
 from src.model.activate import activate, activate_forward
-from unittests.grad.backend import grad_fn, randn_fn
+from unittests.grad.backend import grad_fn, randn_fn, trials, sample_sizes
 
 
-@pytest.mark.parametrize("samples", [2 ** 6, 2 ** 12])
-def test_grad(samples: int, trials: int = 16):  # skipcq: PYL-W0640
+@pytest.mark.parametrize("samples", sample_sizes)
+def test_grad(samples: int):  # skipcq: PYL-W0640
     ctx = Context()
     ctx.is_initializing = False
     randn = randn_fn()

--- a/unittests/grad/activation.py
+++ b/unittests/grad/activation.py
@@ -13,7 +13,8 @@ def test_grad(samples: int):  # skipcq: PYL-W0640
     randn = randn_fn()
     for _ in range(trials):
         inp = randn(samples)
-        grad = grad_fn((samples,), inp)
+        dy = randn(samples)
+        grad = grad_fn(dy, inp)
         out0, = grad(lambda x: activate(x[0]))
         out1, = grad(lambda x: activate_forward(x[0]))
         assert jnp.allclose(out0, out1)

--- a/unittests/grad/activation.py
+++ b/unittests/grad/activation.py
@@ -1,10 +1,9 @@
-import jax
 import pytest
 from jax import numpy as jnp
 
 from src.context import Context
 from src.model.activate import activate, activate_forward
-from unittests.grad.backend import randn_fn
+from unittests.grad.backend import grad_fn, randn_fn
 
 
 @pytest.mark.parametrize("samples", [2 ** 6, 2 ** 12])
@@ -14,6 +13,7 @@ def test_grad(samples: int, trials: int = 16):  # skipcq: PYL-W0640
     randn = randn_fn()
     for _ in range(trials):
         inp = randn(samples)
-        out0 = jax.grad(lambda x: activate(x).mean())(inp)
-        out1 = jax.grad(lambda x: activate_forward(x).mean())(inp)
+        grad = grad_fn((samples,), inp)
+        out0, = grad(lambda x: activate(x[0]))
+        out1, = grad(lambda x: activate_forward(x[0]))
         assert jnp.allclose(out0, out1)

--- a/unittests/grad/backend.py
+++ b/unittests/grad/backend.py
@@ -23,7 +23,7 @@ def randn_fn():
 
 
 def grad_fn(out_shape: typing.Iterable[int], *args):
-    dy = jnp.ones_like(randn_fn()(*out_shape))  # constant for given shape. calling grad_fn twice gives same thing
+    dy = randn_fn()(*out_shape)  # constant for given shape. calling grad_fn twice gives same thing
 
     def _fn(fn):
         return jax.pmap(jax.grad(lambda *x: (fn(*x) * dy).sum()), ParallelAxes.model)(args)

--- a/unittests/grad/backend.py
+++ b/unittests/grad/backend.py
@@ -1,5 +1,4 @@
 import random
-import typing
 
 import jax
 from jax import numpy as jnp
@@ -25,9 +24,7 @@ def randn_fn():
     return _fn
 
 
-def grad_fn(out_shape: typing.Iterable[int], *args):
-    dy = randn_fn()(*out_shape)  # constant for given shape. calling grad_fn twice gives same thing
-
+def grad_fn(dy: jnp.ndarray, *args):
     def _fn(fn):
         return jax.pmap(jax.grad(lambda *x: (fn(*x) * dy).sum()), ParallelAxes.model)(args)
 

--- a/unittests/grad/backend.py
+++ b/unittests/grad/backend.py
@@ -6,6 +6,9 @@ from jax import numpy as jnp
 
 from src.constants import ParallelAxes
 
+trials = 8
+sample_sizes = [2 ** 10, 2 ** 14]
+
 
 def randn_fn():
     rng = random.Random(0)

--- a/unittests/grad/loss.py
+++ b/unittests/grad/loss.py
@@ -67,7 +67,8 @@ def test_grad(z_loss: float, samples: int):  # skipcq: PYL-W0640
     for _ in range(trials):
         src = randn(ctx.dims.batch, ctx.dims.sequence, ctx.dims.features)
         wgt = randn(ctx.dims.features, ctx.dims.vocab)
-        grad = grad_fn((2,), src, wgt)
+        dy = randn(2)
+        grad = grad_fn(dy, src, wgt)
 
         grad0 = grad(lambda x: cross_entropy_loss(ctx, x, tgt)[0])
         grad1 = grad(lambda x: naive_loss(x, tgt, z_loss))

--- a/unittests/grad/loss.py
+++ b/unittests/grad/loss.py
@@ -7,7 +7,7 @@ from src.backend import is_main, matmul
 from src.constants import ParallelAxes
 from src.context import Context
 from src.model.loss import cross_entropy_loss
-from unittests.grad.backend import grad_fn, randn_fn
+from unittests.grad.backend import grad_fn, randn_fn, trials, sample_sizes
 
 
 def mean(x: jnp.ndarray):
@@ -44,8 +44,8 @@ def statistics(name: str, var: jnp.ndarray):
 
 
 @pytest.mark.parametrize("z_loss", [1, 0.01, 0])
-@pytest.mark.parametrize("samples", [2 ** 14])
-def test_value(z_loss: float, samples: int, trials: int = 2):  # skipcq: PYL-W0640
+@pytest.mark.parametrize("samples", sample_sizes)
+def test_value(z_loss: float, samples: int):  # skipcq: PYL-W0640
     ctx, tgt, randn = initialize(z_loss, samples)
     ctx.dims.vocab = 1024
 
@@ -59,8 +59,8 @@ def test_value(z_loss: float, samples: int, trials: int = 2):  # skipcq: PYL-W06
 
 
 @pytest.mark.parametrize("z_loss", [1, 0.01, 0])
-@pytest.mark.parametrize("samples", [2 ** 14])
-def test_grad(z_loss: float, samples: int, trials: int = 2):  # skipcq: PYL-W0640
+@pytest.mark.parametrize("samples", sample_sizes)
+def test_grad(z_loss: float, samples: int):  # skipcq: PYL-W0640
     ctx, tgt, randn = initialize(z_loss, samples)
     ctx.dims.vocab = 1024
 

--- a/unittests/grad/norm.py
+++ b/unittests/grad/norm.py
@@ -1,29 +1,25 @@
-import jax
 import pytest
 from jax import numpy as jnp
 
-from src.constants import ParallelAxes
 from src.context import Context
 from src.model.norm import norm_forward, scale_norm_act
-from unittests.grad.backend import randn_fn
+from unittests.grad.backend import grad_fn, randn_fn
 
 
 @pytest.mark.parametrize("act", [True, False])
 @pytest.mark.parametrize("psum", [True, False])
-@pytest.mark.parametrize("samples", [2 ** 16])
+@pytest.mark.parametrize("samples", [2 ** 10])
 def test_grad(act: bool, psum: bool, samples: int, trials: int = 2):  # skipcq: PYL-W0640
     ctx = Context()
     ctx.is_initializing = False
     randn = randn_fn()
     for trial in range(trials):
         src = randn(samples, ctx.dims.features)
-        wgt = randn(ctx.dims.features)
+        wgt = jnp.ones_like(randn(ctx.dims.features))
+        grad = grad_fn((samples, ctx.dims.features), src, wgt)
 
-        def grad(fn):
-            return jax.pmap(jax.grad(fn), ParallelAxes.model)(src, wgt)
-
-        out0 = grad(lambda x, y: norm_forward(ctx, x, y, psum, act)[0].mean())
-        out1 = grad(lambda x, y: scale_norm_act(ctx, x, ctx.dims.features, y, psum, act).mean())
+        out0 = grad(lambda x: norm_forward(ctx, x[0], x[1], psum, act)[0])
+        out1 = grad(lambda x: scale_norm_act(ctx, x[0], ctx.dims.features, x[1], psum, act))
 
         print(trial)
         assert jnp.allclose(out0[0], out1[0])

--- a/unittests/grad/norm.py
+++ b/unittests/grad/norm.py
@@ -10,12 +10,12 @@ from unittests.grad.backend import randn_fn
 
 @pytest.mark.parametrize("act", [True, False])
 @pytest.mark.parametrize("psum", [True, False])
-@pytest.mark.parametrize("samples", [2 ** 6, 2 ** 12])
-def test_grad(act: bool, psum: bool, samples: int, trials: int = 16):  # skipcq: PYL-W0640
+@pytest.mark.parametrize("samples", [2 ** 16])
+def test_grad(act: bool, psum: bool, samples: int, trials: int = 2):  # skipcq: PYL-W0640
     ctx = Context()
     ctx.is_initializing = False
     randn = randn_fn()
-    for _ in range(trials):
+    for trial in range(trials):
         src = randn(samples, ctx.dims.features)
         wgt = randn(ctx.dims.features)
 
@@ -24,4 +24,7 @@ def test_grad(act: bool, psum: bool, samples: int, trials: int = 16):  # skipcq:
 
         out0 = grad(lambda x, y: norm_forward(ctx, x, y, psum, act)[0].mean())
         out1 = grad(lambda x, y: scale_norm_act(ctx, x, ctx.dims.features, y, psum, act).mean())
-        assert jnp.allclose(out0, out1)
+
+        print(trial)
+        assert jnp.allclose(out0[0], out1[0])
+        assert jnp.allclose(out0[1], out1[1])

--- a/unittests/grad/norm.py
+++ b/unittests/grad/norm.py
@@ -8,10 +8,14 @@ from unittests.grad.backend import grad_fn, randn_fn
 
 @pytest.mark.parametrize("act", [True, False])
 @pytest.mark.parametrize("psum", [True, False])
-@pytest.mark.parametrize("samples", [2 ** 10])
-def test_grad(act: bool, psum: bool, samples: int, trials: int = 2):  # skipcq: PYL-W0640
+@pytest.mark.parametrize("zero_mean", [True, False])
+@pytest.mark.parametrize("samples", sample_sizes)
+@pytest.mark.parametrize("power", [1, 2, 3, 4])
+def test_grad(act: bool, psum: bool, zero_mean: bool, samples: int, power: int):  # skipcq: PYL-W0640
     ctx = Context()
     ctx.is_initializing = False
+    ctx.model.norm.zero_mean = zero_mean
+    ctx.model.norm.power = power
     randn = randn_fn()
     for trial in range(trials):
         src = randn(samples, ctx.dims.features)

--- a/unittests/grad/norm.py
+++ b/unittests/grad/norm.py
@@ -20,7 +20,8 @@ def test_grad(act: bool, psum: bool, zero_mean: bool, samples: int, power: int):
     for trial in range(trials):
         src = randn(samples, ctx.dims.features)
         wgt = randn(ctx.dims.features)
-        grad = grad_fn((samples, ctx.dims.features), src, wgt)
+        dy = randn(samples, ctx.dims.features)
+        grad = grad_fn(dy, src, wgt)
 
         out0 = grad(lambda x: norm_forward(ctx, x[0], x[1], psum, act)[0])
         out1 = grad(lambda x: scale_norm_act(ctx, x[0], ctx.dims.features, x[1], psum, act))

--- a/unittests/grad/norm.py
+++ b/unittests/grad/norm.py
@@ -3,7 +3,7 @@ from jax import numpy as jnp
 
 from src.context import Context
 from src.model.norm import norm_forward, scale_norm_act
-from unittests.grad.backend import grad_fn, randn_fn
+from unittests.grad.backend import grad_fn, randn_fn, trials, sample_sizes
 
 
 @pytest.mark.parametrize("act", [True, False])

--- a/unittests/grad/norm.py
+++ b/unittests/grad/norm.py
@@ -15,7 +15,7 @@ def test_grad(act: bool, psum: bool, samples: int, trials: int = 2):  # skipcq: 
     randn = randn_fn()
     for trial in range(trials):
         src = randn(samples, ctx.dims.features)
-        wgt = jnp.ones_like(randn(ctx.dims.features))
+        wgt = randn(ctx.dims.features)
         grad = grad_fn((samples, ctx.dims.features), src, wgt)
 
         out0 = grad(lambda x: norm_forward(ctx, x[0], x[1], psum, act)[0])


### PR DESCRIPTION
ScaleNorm:
![grafik](https://user-images.githubusercontent.com/39779310/189501934-3b0de839-6897-4c5c-8f03-8c09183cdf6e.png)

LayerNorm:
![grafik](https://user-images.githubusercontent.com/39779310/189502066-265c699c-a521-46ce-8a15-200296773acb.png)

Otherwise, both models have identical settings, so purely by switching LayerNorm with ScaleNorm (both L2), the model becomes 25% faster while achieving the same (or better) convergence:
![grafik](https://user-images.githubusercontent.com/39779310/189502100-07687de5-3460-48ef-93e7-237d593eed61.png)

L1-Norm has the same speed but worse loss initially:
![grafik](https://user-images.githubusercontent.com/39779310/189504333-08c8c645-ee16-4b42-ac6d-f74db5e90ceb.png)
![grafik](https://user-images.githubusercontent.com/39779310/189504342-e2a78e8c-c8a8-4c48-a543-f05ae1662f81.png)


Additionally, this PR makes grad checks tougher to pass, as all models don't just get random parameters but also a random output gradient. This changed input ensures that we use the output gradient correctly, as our custom_grad functions could otherwise ignore it.