### PR TITLE
Weight-Tie MoE

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -58,7 +58,7 @@ def is_model(param_name: str):
 
 
 def is_stacked(ctx: Context, param_name: str, val: jnp.ndarray):
-    return val.shape[0] == ctx.dims.depth and not is_model(param_name)
+    return val.shape[0] == ctx.dims.depth and is_model(param_name)
 
 
 def conv(inp: jnp.ndarray, weight: jnp.ndarray, padding: typing.List[typing.Tuple[int, int]], groups: int):

--- a/src/backend.py
+++ b/src/backend.py
@@ -169,4 +169,4 @@ def loop(fn: typing.Callable, fn_input: typing.Any, steps: int, unroll: int = 1)
 
 def pattern_match(gen_fn: typing.Callable[[int], typing.Callable[[], jnp.ndarray]], cases: int, predicate: jnp.ndarray,
                   base: jnp.ndarray):
-    return lax.switch(predicate, [gen_fn(i) for i in range(cases)], base)
+    return lax.switch(predicate % cases, [gen_fn(i) for i in range(cases)], base)

--- a/src/backend.py
+++ b/src/backend.py
@@ -123,9 +123,9 @@ def get_param(ctx: Context, name: str, shape: typing.Optional[typing.List[int]] 
               init_val: typing.Optional[jnp.ndarray] = None,
               tied: bool = False) -> jnp.ndarray:
 
-    add_depth = ctx.add_depth and not tied
-    if add_depth:
+    if not tied:
         name = name + '_stacked'
+    add_depth = ctx.add_depth and not tied
 
     prefix_name = prefixed_name(ctx, name)
 

--- a/src/backend.py
+++ b/src/backend.py
@@ -57,8 +57,8 @@ def is_model(param_name: str):
     return "/step:" in param_name and '/optimizer' not in param_name
 
 
-def is_stacked(ctx: Context, param_name: str, val: jnp.ndarray):
-    return val.shape[0] == ctx.dims.depth and is_model(param_name)
+def is_stacked(param_name: str):
+    return param_name.endswith('_stacked') and is_model(param_name)
 
 
 def conv(inp: jnp.ndarray, weight: jnp.ndarray, padding: typing.List[typing.Tuple[int, int]], groups: int):
@@ -122,6 +122,11 @@ def get_param(ctx: Context, name: str, shape: typing.Optional[typing.List[int]] 
               lr_scale: float = 1, dtype: typing.Optional[jnp.float32] = None,
               init_val: typing.Optional[jnp.ndarray] = None,
               tied: bool = False) -> jnp.ndarray:
+
+    add_depth = ctx.add_depth and not tied
+    if add_depth:
+        name = name + '_stacked'
+
     prefix_name = prefixed_name(ctx, name)
 
     if dtype is None:
@@ -130,8 +135,6 @@ def get_param(ctx: Context, name: str, shape: typing.Optional[typing.List[int]] 
     else:
         computation_dtype = dtype
         storage_dtype = dtype
-
-    add_depth = ctx.add_depth and not tied
 
     if prefix_name not in ctx.parameters:
         if init_val is not None:

--- a/src/backend.py
+++ b/src/backend.py
@@ -169,7 +169,4 @@ def loop(fn: typing.Callable, fn_input: typing.Any, steps: int, unroll: int = 1)
 
 def pattern_match(gen_fn: typing.Callable[[int], typing.Callable[[], jnp.ndarray]], cases: int, predicate: jnp.ndarray,
                   base: jnp.ndarray):
-    new = base
-    for i in range(cases):
-        new = lax.cond(i == predicate, gen_fn(i), lambda _: new, base)
-    return new
+    return lax.switch(predicate, [gen_fn(i) for i in range(cases)], base)

--- a/src/backend.py
+++ b/src/backend.py
@@ -53,8 +53,12 @@ def tuple_int(obj: INT_OR_TUPLE) -> typing.Sequence[int]:
     raise ValueError
 
 
+def is_model(param_name: str):
+    return "/step:" in param_name and '/optimizer' not in param_name
+
+
 def is_stacked(ctx: Context, param_name: str, val: jnp.ndarray):
-    return val.shape[0] == ctx.dims.depth and "/step:" in param_name and '/optimizer' not in param_name
+    return val.shape[0] == ctx.dims.depth and not is_model(param_name)
 
 
 def conv(inp: jnp.ndarray, weight: jnp.ndarray, padding: typing.List[typing.Tuple[int, int]], groups: int):

--- a/src/model/conv.py
+++ b/src/model/conv.py
@@ -8,7 +8,7 @@ from src.model.norm import prenorm, scale_norm_act
 
 
 @with_context()
-def conv(ctx: Context, inp: jnp.ndarray, conv_kernel: int, in_features: int, out_features: int):
+def conv(ctx: Context, inp: jnp.ndarray, conv_kernel: int, in_features: int, out_features: int, tied: bool = False):
     fan_in = jnp.arange(conv_kernel, 0, -1, dtype=ctx.model.storage_dtype)
     fan_in = (1 - 1 / (conv_kernel * ctx.model.conv_scale + ctx.model.conv_shift)) ** fan_in
     fan_in = fan_in / fan_in.sum()

--- a/src/model/conv.py
+++ b/src/model/conv.py
@@ -13,7 +13,8 @@ def conv(ctx: Context, inp: jnp.ndarray, conv_kernel: int, in_features: int, out
     fan_in = (1 - 1 / (conv_kernel * ctx.model.conv_scale + ctx.model.conv_shift)) ** fan_in
     fan_in = fan_in / fan_in.sum()
     fan_in = fan_in.reshape(1, 1, -1)
-    weight = get_param(ctx, "weight", [out_features, conv_kernel, in_features], column_axes=2, lr_scale=fan_in)
+    weight = get_param(ctx, "weight", [out_features, conv_kernel, in_features], column_axes=2, lr_scale=fan_in,
+                       tied=tied)
     if ctx.is_initializing:
         return jnp.zeros(inp.shape[:-1] + (out_features,))
     return lax_conv(inp, weight, [(conv_kernel - 1, 0)], 1)

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -54,8 +54,6 @@ def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.nd
     else:
         params = {p: k for p, k in ctx.parameters.items() if is_stacked(p)}
         shared_params = {p: k for p, k in ctx.parameters.items() if is_model(p) and not is_stacked(p)}
-        print("params keys", {p: k.shape for p, k in params.items()})
-        print("shared_params keys", {p: k.shape for p, k in shared_params.items()})
         src, _ = lax.scan(step(ctx, shared_params), src, (params, jnp.arange(ctx.dims.depth)), ctx.dims.depth)
     out = revnet_out(src)
     out = scale_norm_act(ctx, out, ctx.dims.features, act=False)

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -52,8 +52,8 @@ def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.nd
         ctx.parameters = step(ctx, {})(src, (ctx.parameters, jnp.zeros([], dtype=jnp.int32)))
         ctx.add_depth = False
     else:
-        params = {p: k for p, k in ctx.parameters.items() if is_stacked(ctx, p, k)}
-        shared_params = {p: k for p, k in ctx.parameters.items() if is_model(p) and not is_stacked(ctx, p, k)}
+        params = {p: k for p, k in ctx.parameters.items() if is_stacked(p)}
+        shared_params = {p: k for p, k in ctx.parameters.items() if is_model(p) and not is_stacked(p)}
         print("params keys", {p: k.shape for p, k in params.items()})
         print("shared_params keys", {p: k.shape for p, k in shared_params.items()})
         src, _ = lax.scan(step(ctx, shared_params), src, (params, jnp.arange(ctx.dims.depth)), ctx.dims.depth)

--- a/src/model/main.py
+++ b/src/model/main.py
@@ -54,6 +54,8 @@ def body_ctx(ctx: Context, src: jnp.ndarray) -> typing.Union[typing.Tuple[jnp.nd
     else:
         params = {p: k for p, k in ctx.parameters.items() if is_stacked(ctx, p, k)}
         shared_params = {p: k for p, k in ctx.parameters.items() if is_model(p) and not is_stacked(ctx, p, k)}
+        print("params keys", list(params.keys()))
+        print("shared_params keys", list(shared_params.keys()))
         src, _ = lax.scan(step(ctx, shared_params), src, (params, jnp.arange(ctx.dims.depth)), ctx.dims.depth)
     out = revnet_out(src)
     out = scale_norm_act(ctx, out, ctx.dims.features, act=False)

--- a/src/model/moe.py
+++ b/src/model/moe.py
@@ -40,7 +40,7 @@ def dense_moe(ctx: Context, inp: jnp.ndarray) -> jnp.ndarray:
 
     # Devices^2 more parameters than normal bottleneck block but only Devices-times more flops due to sparsity above
     inp = scale_norm_act(ctx, inp, big_params)
-    inp = conv(ctx, inp, ctx.dims.inner_bottleneck_kernel, big_params, big_params)
+    inp = conv(ctx, inp, ctx.dims.inner_bottleneck_kernel, big_params, big_params, tied=True)
     inp = scale_norm_act(ctx, inp, big_params)
 
     # [Batch, SequenceSlice, Features * Devices]  ->  [Batch, Sequence, Features]  (PixelShuffle across devices)

--- a/src/model/norm.py
+++ b/src/model/norm.py
@@ -55,8 +55,7 @@ def scale_norm_act(ctx: Context, inp: jnp.ndarray, feature_dim: int, weight: typ
                    psum: bool = False, act: bool = True) -> jnp.ndarray:
     run_type = jnp.promote_types(ctx.model.computation_dtype, jnp.float32)
     if weight is None:
-        weight = get_param(ctx, "scale", [feature_dim], std=0, mean=1,
-                           dtype=run_type)
+        weight = get_param(ctx, "scale", [feature_dim], std=0, mean=1, dtype=run_type)
 
     if ctx.is_initializing:
         return inp

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -34,7 +34,7 @@ def sm3(ctx: Context, grad: jnp.ndarray) -> jnp.ndarray:
 
 def small_parameter(ctx: Context, param_name: str, grad: jnp.ndarray) -> bool:
     is_small = "norm" in param_name.lower() or "rezero" in param_name.lower()
-    is_small |= grad.ndim < (2 + is_stacked(ctx, param_name, grad))
+    is_small |= grad.ndim < (2 + is_stacked(param_name))
     return is_small
 
 
@@ -95,7 +95,7 @@ def shampoo(ctx: Context, grad: jnp.ndarray, step: jnp.ndarray) -> jnp.ndarray: 
 
 def norm(ctx: Context, param_name: str, val: jnp.ndarray):
     val = lax.square(val)
-    if is_stacked(ctx, param_name, val):
+    if is_stacked(param_name):
         val = val.sum(tuple(range(1, val.ndim))).reshape((-1,) + (1,) * (val.ndim - 1))
     else:
         val = val.sum()
@@ -143,7 +143,7 @@ def update(ctx: Context, grads: typing.Dict[str, jnp.ndarray], step: jnp.ndarray
 
         weight_update = adam(ctx, grad, step)
         if not small_parameter(ctx, param_name, grad):
-            if is_stacked(ctx, param_name, grad):
+            if is_stacked(param_name):
                 shampoo_update = jnp.stack([shampoo(ctx, grad[i], step) for i in range(grad.shape[0])], 0)
             else:
                 shampoo_update = shampoo(ctx, grad, step)

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -32,7 +32,7 @@ def sm3(ctx: Context, grad: jnp.ndarray) -> jnp.ndarray:
     return grad * stable_rsqrt(weight_update, ctx.optimizer.epsilon)
 
 
-def small_parameter(ctx: Context, param_name: str, grad: jnp.ndarray) -> bool:
+def small_parameter(param_name: str, grad: jnp.ndarray) -> bool:
     is_small = "norm" in param_name.lower() or "rezero" in param_name.lower()
     is_small |= grad.ndim < (2 + is_stacked(param_name))
     return is_small
@@ -42,13 +42,13 @@ def small_parameter(ctx: Context, param_name: str, grad: jnp.ndarray) -> bool:
 def ema(ctx: Context, inp: jnp.ndarray, step: jnp.ndarray, beta: float, quantize: typing.Optional[bool] = None,
         init_val: typing.Optional[jnp.ndarray] = None, heavyball: bool = None, nesterov: bool = None) -> jnp.ndarray:
     if quantize is None:
-        quantize = not small_parameter(ctx, ctx.global_prefix, inp)
+        quantize = not small_parameter(ctx.global_prefix, inp)
     if heavyball is None:
         heavyball = ctx.optimizer.heavyball
     if nesterov is None:
         heavyball = ctx.optimizer.nesterov
     state = get_param(ctx, "momentum_buffer", inp.shape, dtype=jnp.bfloat16 if quantize else inp.dtype,
-                      init_val=jnp.zeros_like(inp) if init_val is None else init_val)
+                      init_val=jnp.zeros_like(inp) if init_val is None else init_val, tied=True)
     new_state = state.astype(inp.dtype) * beta + inp * (1 if heavyball else (1 - beta))
     assign(ctx, "momentum_buffer", new_state)
     if not heavyball:  # non-heavyball momentum needs to be debiased
@@ -77,7 +77,7 @@ def shampoo(ctx: Context, grad: jnp.ndarray, step: jnp.ndarray) -> jnp.ndarray: 
         eye = jnp.eye(old_stat.shape[0], dtype=ctx.model.storage_dtype)
         new_stat = ema(ctx, old_stat, step, 1 - ctx.optimizer.shampoo_beta2, True, init_val=eye * ctx.optimizer.epsilon,
                        nesterov=False, heavyball=False)
-        prev_p = get_param(ctx, f'preconditioner_{i}', old_stat.shape, dtype=grad.dtype, init_val=eye)
+        prev_p = get_param(ctx, f'preconditioner_{i}', old_stat.shape, dtype=grad.dtype, init_val=eye, tied=True)
         if ctx.is_initializing:
             continue
 
@@ -93,7 +93,7 @@ def shampoo(ctx: Context, grad: jnp.ndarray, step: jnp.ndarray) -> jnp.ndarray: 
     return preconditioner.preconditioned_grad(grad, new_preconditioners)
 
 
-def norm(ctx: Context, param_name: str, val: jnp.ndarray):
+def norm(param_name: str, val: jnp.ndarray):
     val = lax.square(val)
     if is_stacked(param_name):
         val = val.sum(tuple(range(1, val.ndim))).reshape((-1,) + (1,) * (val.ndim - 1))
@@ -102,19 +102,19 @@ def norm(ctx: Context, param_name: str, val: jnp.ndarray):
     return val
 
 
-def clip_norm(ctx: Context, param_name: str, val: jnp.ndarray, min_norm: float) -> jnp.ndarray:
-    return jnp.maximum(jnp.sqrt(norm(ctx, param_name, val)), min_norm)
+def clip_norm(param_name: str, val: jnp.ndarray, min_norm: float) -> jnp.ndarray:
+    return jnp.maximum(jnp.sqrt(norm(param_name, val)), min_norm)
 
 
 def adaptive_gradient_clipping(ctx: Context, param_name: str, grad: jnp.ndarray) -> jnp.ndarray:
-    grd_norm = clip_norm(ctx, param_name, grad, ctx.optimizer.epsilon)
-    wgt_norm = clip_norm(ctx, param_name, ctx.parameters[param_name], 1e-3)
+    grd_norm = clip_norm(param_name, grad, ctx.optimizer.epsilon)
+    wgt_norm = clip_norm(param_name, ctx.parameters[param_name], 1e-3)
     grad_scale = jnp.minimum(wgt_norm / grd_norm * ctx.optimizer.gradient_clip, 1)
     return grad * grad_scale
 
 
-def graft(ctx: Context, param_name: str, magnitude: jnp.ndarray, direction: jnp.ndarray) -> jnp.ndarray:
-    scale = jnp.sqrt(norm(ctx, param_name, magnitude) / jnp.maximum(norm(ctx, param_name, direction), 1e-16))
+def graft(param_name: str, magnitude: jnp.ndarray, direction: jnp.ndarray) -> jnp.ndarray:
+    scale = jnp.sqrt(norm(param_name, magnitude) / jnp.maximum(norm(param_name, direction), 1e-16))
     return scale * direction
 
 
@@ -142,13 +142,13 @@ def update(ctx: Context, grads: typing.Dict[str, jnp.ndarray], step: jnp.ndarray
         grad = adaptive_gradient_clipping(ctx, param_name, grad)
 
         weight_update = adam(ctx, grad, step)
-        if not small_parameter(ctx, param_name, grad):
+        if not small_parameter(param_name, grad):
             if is_stacked(param_name):
                 shampoo_update = jnp.stack([shampoo(ctx, grad[i], step) for i in range(grad.shape[0])], 0)
             else:
                 shampoo_update = shampoo(ctx, grad, step)
             shampoo_update = ema(ctx, shampoo_update, step, 1 - ctx.optimizer.momentum_beta)
-            weight_update = graft(ctx, param_name, weight_update, shampoo_update)
+            weight_update = graft(param_name, weight_update, shampoo_update)
             ctx.parameters[param_name] = (1 + ctx.optimizer.weight_decay * parameter_lr) * ctx.parameters[param_name]
         weight_update = weight_update.astype(ctx.parameters[param_name].dtype)
         ctx.parameters[param_name] = weight_update * parameter_lr + ctx.parameters[param_name]


### PR DESCRIPTION
* `is_stacked`: check for `_stacked` parameter-name suffix instead of dim size
* `pattern_match`: looped lax.cond to single lax.switch call

This PR reduces the number of parameters from 9.6B to 1.6B and performs as well as untied MoE for the first 2 billion tokens:
![grafik](https://user-images.githubusercontent.com/39779310/193461940-5c2776a0-58a8-456b-9420-09afe60b1f43.png)

With that, both are significantly better than the baseline:
![grafik](https://user-images.githubusercontent.com/39779310/193462008-83f67b09-3ab5-4a97-ba95-54651799deec.png)

